### PR TITLE
fix(MOVES): remove dangling pdb import

### DIFF
--- a/src/FPEAM/MOVES.py
+++ b/src/FPEAM/MOVES.py
@@ -1,4 +1,3 @@
-import pdb
 import os
 
 import numpy as np


### PR DESCRIPTION
## Summary

Removes the leftover module-level `import pdb` from `src/FPEAM/MOVES.py`. No `pdb.set_trace()` call remains in source, so the import served no purpose and introduced an unnecessary dependency on the debugger module.

## Validation

```
pixi run env PYTHONPATH=src python -m unittest discover -s tests/unit_tests -p 'test_*.py'
```

```
Ran 1 test in 0.469s
OK
```

Closes the `p0-remove-pdb-traps` slice.
