### PR TITLE
fix(Data): tighten init validation and fix RegionFipsMap dup detection

### DIFF
--- a/src/FPEAM/Data.py
+++ b/src/FPEAM/Data.py
@@ -17,22 +17,26 @@ class Data(pd.DataFrame):
 
     def __init__(self, df=None, fpath=None, columns=None, backfill=True):
 
-        _df = pd.DataFrame({}) if df is None and fpath is None else load(fpath=fpath,
-                                                                         columns=columns)
+        if df is not None:
+            _df = pd.DataFrame(df)
+        elif fpath is not None:
+            _df = load(fpath=fpath, columns=columns)
+        else:
+            _df = pd.DataFrame({})
 
         super(Data, self).__init__(data=_df)
 
         self.source = fpath or 'DataFrame'
 
-        _valid = self.validate()
-
-        try:
-            assert _valid is True
-        except AssertionError:
-            if df is not None or fpath is not None:
-                raise RuntimeError('{} failed validation'.format(__name__, ))
-            else:
-                pass
+        # Only enforce validation when the caller supplied data; empty
+        # default construction is allowed for subclassing/composition.
+        if df is not None or fpath is not None:
+            if not self.validate():
+                raise RuntimeError(
+                    '{cls} failed validation (source={src})'.format(
+                        cls=type(self).__name__, src=self.source,
+                    )
+                )
 
         if backfill:
             for _column in self.COLUMNS:
@@ -347,12 +351,12 @@ class RegionFipsMap(Data):
             assert self.region.nunique() == self.fips.nunique()
         except AssertionError:
             _region_counts = self.region.value_counts()
-            _dup_regions = list(_region_counts.loc[_region_counts != 1].values)
+            _dup_regions = list(_region_counts.loc[_region_counts != 1].index)
             if _dup_regions:
                 LOGGER.error('Duplicated region values in region_fips_map data: %s' % _dup_regions)
 
             _fips_counts = self.fips.value_counts()
-            _dup_fips = list(_fips_counts.loc[_region_counts != 1].values)
+            _dup_fips = list(_fips_counts.loc[_fips_counts != 1].index)
             if _dup_fips:
                 LOGGER.error('Duplicated FIPS values in region_fips_map data: %s' % _dup_fips)
             raise ValueError('region_fips_map data must have only 1 '

--- a/tests/unit_tests/test_data.py
+++ b/tests/unit_tests/test_data.py
@@ -1,0 +1,71 @@
+"""Focused tests for FPEAM.Data base class validation flow.
+
+Covers the regression fixed in `Data.__init__` where:
+- the RuntimeError message used the module __name__ instead of the class name
+- failed validation on caller-supplied data was caught and silently swallowed
+- the `df=` keyword was effectively unused because `load()` always ran when
+  `fpath` was None, crashing on `os.path.abspath(None)` before validation
+"""
+import unittest
+
+import pandas as pd
+
+from FPEAM.Data import Data, RegionFipsMap
+
+
+class _StrictData(Data):
+    """Subclass that fails validation when the frame is missing a 'required' column."""
+
+    COLUMNS = (
+        {'name': 'required', 'type': str, 'index': True, 'backfill': None},
+    )
+
+    def __init__(self, df=None, fpath=None, backfill=True):
+        super().__init__(
+            df=df,
+            fpath=fpath,
+            columns={c['name']: c['type'] for c in self.COLUMNS},
+            backfill=backfill,
+        )
+
+    def validate(self):
+        return 'required' in self.columns and not self.empty
+
+
+class DataInitTest(unittest.TestCase):
+
+    def test_default_construction_does_not_raise(self):
+        """Data() with no arguments yields an empty frame without enforcing validation."""
+        d = Data()
+        self.assertTrue(d.empty)
+        self.assertEqual(d.source, 'DataFrame')
+
+    def test_explicit_empty_df_triggers_validation_failure(self):
+        """Passing an explicit empty DataFrame is treated as supplied data and must validate."""
+        with self.assertRaises(RuntimeError) as ctx:
+            _StrictData(df=pd.DataFrame())
+        self.assertIn('_StrictData', str(ctx.exception),
+                      msg='RuntimeError should name the failing subclass')
+        self.assertIn('source=', str(ctx.exception),
+                      msg='RuntimeError should expose the data source for debugging')
+
+    def test_valid_df_constructs_cleanly(self):
+        d = _StrictData(df=pd.DataFrame({'required': ['a', 'b']}))
+        self.assertFalse(d.empty)
+        self.assertEqual(d.source, 'DataFrame')
+
+
+class RegionFipsMapValidationTest(unittest.TestCase):
+
+    def test_duplicate_region_raises(self):
+        """RegionFipsMap.validate raises ValueError when regions or FIPS are non-unique."""
+        df = pd.DataFrame({
+            'region': ['r1', 'r1', 'r2'],
+            'fips': ['00001', '00002', '00003'],
+        })
+        with self.assertRaises(ValueError):
+            RegionFipsMap(df=df, backfill=False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Three related fixes in `src/FPEAM/Data.py` plus a new `tests/unit_tests/test_data.py` covering the regression.

## `Data.__init__`

- The `df=` keyword was effectively unused: `load()` was called whenever `(df is None and fpath is None)` was false, which included the case where `df` was a real DataFrame. `load()` then crashed on `os.path.abspath(None)` before validation could run. Now: prefer `df`, fall back to `fpath`, else empty.
- RuntimeError message used the module `__name__` (`FPEAM.Data`) instead of the failing subclass name. Replaced with `type(self).__name__` and added `source=<path>` so failures are debuggable.
- Removed the `try/except/assert` dance. Empty default construction is still allowed (validate is skipped when both `df` and `fpath` are `None`). When the caller supplies data and `validate()` returns False, raise.

## `RegionFipsMap.validate`

- The fips-duplicate filter used `_region_counts != 1` instead of `_fips_counts != 1`, which raised an unalignable `IndexingError` when the two `value_counts` had different shapes. Fixed.
- The duplicate lists captured `value_counts().values` (the counts) instead of `.index` (the actual duplicated identifiers). Switched to `.index` so log messages name the bad data.

## Tests

- Default empty construction does not raise.
- Explicit empty DataFrame triggers `RuntimeError` that names the subclass and the source.
- Valid non-empty df constructs cleanly.
- `RegionFipsMap` with a duplicate region raises `ValueError`.

## Validation

```
pixi run env PYTHONPATH=src python -m pytest tests/unit_tests/ -v
5 passed, 1 warning in 1.47s
```
