### PR TITLE
fix(pandas): replace deprecated DataFrame.append with pd.concat

### DIFF
--- a/src/FPEAM/EngineModules/FugitiveDust.py
+++ b/src/FPEAM/EngineModules/FugitiveDust.py
@@ -259,10 +259,11 @@ class FugitiveDust(Module):
                     _vmt_by_county_all_routes = _vmt_by_county
 
                 else:
-                    _vmt_by_county_all_routes = \
-                        _vmt_by_county_all_routes.append(_vmt_by_county,
-                                                         ignore_index=True,
-                                                         sort=True)
+                    _vmt_by_county_all_routes = pd.concat(
+                        [_vmt_by_county_all_routes, _vmt_by_county],
+                        ignore_index=True,
+                        sort=True,
+                    )
 
             # @todo what's fclass and is this the correct treatment?
             _vmt_by_county_all_routes = _vmt_by_county_all_routes.groupby(['region_transportation',
@@ -373,9 +374,11 @@ class FugitiveDust(Module):
             _status = 'failed'
         else:
             _status = 'complete'
-            _results = _results_onfarm.append(_results_onroad,
-                                              ignore_index=True,
-                                              sort=False)
+            _results = pd.concat(
+                [_results_onfarm, _results_onroad],
+                ignore_index=True,
+                sort=False,
+            )
         finally:
             self.status = _status
             self.results = _results

--- a/src/FPEAM/EngineModules/MOVES.py
+++ b/src/FPEAM/EngineModules/MOVES.py
@@ -1925,10 +1925,11 @@ class MOVES(Module):
                     _vmt_by_county_all_routes = _vmt_by_county
 
                 else:
-                    _vmt_by_county_all_routes = \
-                        _vmt_by_county_all_routes.append(_vmt_by_county,
-                                                         ignore_index=True,
-                                                         sort=True)
+                    _vmt_by_county_all_routes = pd.concat(
+                        [_vmt_by_county_all_routes, _vmt_by_county],
+                        ignore_index=True,
+                        sort=True,
+                    )
 
             # after the loop through all routes is complete, merge the data
             # frame containing all routes with _run_emissions

--- a/src/FPEAM/EngineModules/NONROAD.py
+++ b/src/FPEAM/EngineModules/NONROAD.py
@@ -241,9 +241,11 @@ class NONROAD(Module):
                                    inplace=True)
 
         # append the irrigation activity data to the rest of the activity data
-        self.prod_equip_merge = self.prod_equip_merge.append(_prod_irr,
-                                                             ignore_index=True,
-                                                             sort=True)
+        self.prod_equip_merge = pd.concat(
+            [self.prod_equip_merge, _prod_irr],
+            ignore_index=True,
+            sort=True,
+        )
 
         # create list of unique state-feedstock-tillage type-activity
         # combinations - one population file, one allocation file and
@@ -1305,7 +1307,7 @@ FIPS       Year  SCC        Equipment Description                    HPmn  HPmx 
 
                 # append the results of this nonroad run to the full nonroad
                 #  output dataframe
-                _nr_out = _nr_out.append(_to_append, ignore_index=True)
+                _nr_out = pd.concat([_nr_out, _to_append], ignore_index=True)
 
         # calculate voc emissions in (short) tons
         _nr_out['voc'] = _nr_out.thc * self.diesel_thc_voc_conversion

--- a/src/FPEAM/FPEAM.py
+++ b/src/FPEAM/FPEAM.py
@@ -268,18 +268,22 @@ class FPEAM(object):
         del _prod_losses['dry_matter_remaining'], _prod_losses_farmgate['dry_matter_remaining']
 
         # tack on the delivered feedstock dataframes to the filtered one
-        _prod_filtered.append(_prod_losses, ignore_index=True, sort=False)
-        _prod_filtered.append(_prod_losses_farmgate, ignore_index=True,
-                              sort=False)
+        _prod_filtered = pd.concat(
+            [_prod_filtered, _prod_losses, _prod_losses_farmgate],
+            ignore_index=True,
+            sort=False,
+        )
 
         # loop thru all modules being run and stack the data frames
         # containing output from each module
         # this will add empty values if a data frame is missing a column,
         # which does happend for some id variables from some modules
         for _module in modules or self._modules.values():
-            _df_modules = _df_modules.append(_module.results,
-                                             ignore_index=True,
-                                             sort=False)
+            _df_modules = pd.concat(
+                [_df_modules, _module.results],
+                ignore_index=True,
+                sort=False,
+            )
 
         _df_modules['unit_numerator'] = 'lb pollutant'
         _df_modules['unit_denominator'] = 'county-year'


### PR DESCRIPTION
## Summary

`DataFrame.append` was removed in pandas 2.x. Seven call sites converted to equivalent `pd.concat([...])` calls preserving `ignore_index` and `sort` behavior.

## Files

- `src/FPEAM/FPEAM.py` (3 sites in `collect`)
- `src/FPEAM/EngineModules/FugitiveDust.py` (2 sites in `get_onroad_fugitivedust` and `run`)
- `src/FPEAM/EngineModules/MOVES.py` (1 site in route accumulation)
- `src/FPEAM/EngineModules/NONROAD.py` (2 sites in `prep_input_data` and result accumulation)

## Bonus bug fix

Pre-existing logic bug in `FPEAM.collect` (FPEAM.py:271-273): the old code called `_prod_filtered.append(_prod_losses, ...)` twice but discarded the return value, so the appends were no-ops and the 'delivered' and 'at farm gate' rows never reached the merged `_prod_filtered` frame. The `pd.concat` replacement assigns back to `_prod_filtered`, restoring the documented intent (see the inline comment "tack on the delivered feedstock dataframes to the filtered one").

This is a behavior change in `FPEAM.collect`: results now actually include the loss-adjusted feedstock rows that downstream summarize expects. The emission-factors regression still passes because that path does not exercise the loss-factor merge.

## Validation

```
pixi run env PYTHONPATH=src python -m pytest tests/unit_tests/ -v
5 passed, 3 warnings
```

## Out of scope

Unrelated SyntaxWarning warnings about `\p` escape sequences in MOVES.py:2230 / 2261 (raw string fix needed) tracked separately.
