### PR TITLE
test: expand coverage for IO and EmissionFactors; fix pandas 2.x compat

### DIFF
--- a/src/FPEAM/IO.py
+++ b/src/FPEAM/IO.py
@@ -76,14 +76,15 @@ def load(fpath, columns, memory_map=True, header=0, **kwargs):
         _df = pd.read_csv(filepath_or_buffer=fpath, sep=',', dtype=columns,
                           usecols=columns.keys(), memory_map=memory_map, header=header, **kwargs)
     except ValueError as e:
-        if e.__str__() == 'Usecols do not match names.':
-            from collections import Counter
-            _df = pd.read_table(filepath_or_buffer=fpath, sep=',', dtype=columns,
-                                memory_map=memory_map, header=header, **kwargs)
-            _df_columns = Counter(_df.columns)
-            _cols = list(set(columns.keys()) - set(_df_columns))
-            raise ValueError('%(f)s missing columns: %(cols)s' % (dict(f=fpath, cols=_cols)))
+        _msg = str(e)
+        # pandas raises "Usecols do not match names." (pandas <2) or
+        # "Usecols do not match columns" (pandas >=2) for missing columns
+        if 'Usecols do not match' in _msg:
+            _df_check = pd.read_csv(filepath_or_buffer=fpath, sep=',',
+                                    memory_map=memory_map, header=header)
+            _missing = list(set(columns.keys()) - set(_df_check.columns))
+            raise ValueError('%s missing columns: %s' % (fpath, _missing))
         else:
-            raise e
+            raise
     else:
         return _df

--- a/tests/unit_tests/test_emissionfactors_extended.py
+++ b/tests/unit_tests/test_emissionfactors_extended.py
@@ -1,0 +1,108 @@
+"""Edge-case tests for EmissionFactors module.
+
+These complement the golden-CSV regression in test_emissionfactors.py with
+focused unit-level checks that do not require a full production dataset.
+"""
+import pytest
+import pandas as pd
+
+from FPEAM.EngineModules import EmissionFactors
+from FPEAM.IO import load_configs, _resource_path, CONFIG_FOLDER
+
+
+@pytest.fixture(scope='module')
+def ef_config():
+    return load_configs(_resource_path('%s/run_config.ini' % CONFIG_FOLDER))
+
+
+def _make_equipment(feedstock='corn grain', resource='nitrogen', rate=1.0):
+    return pd.DataFrame([{
+        'feedstock': feedstock, 'tillage_type': 'conventional tillage',
+        'equipment_group': 'grp1', 'rotation_year': 1,
+        'activity': 'chemical application',
+        'equipment_name': 'tractor', 'equipment_horsepower': 100.0,
+        'resource': resource, 'rate': rate,
+        'unit_numerator': 'lb', 'unit_denominator': 'ac',
+    }])
+
+
+def _make_production(feedstock='corn grain', feedstock_measure='harvested',
+                     feedstock_amount=100.0):
+    return pd.DataFrame([{
+        'feedstock': feedstock, 'tillage_type': 'conventional tillage',
+        'region_production': '17031', 'region_destination': '17031',
+        'equipment_group': 'grp1',
+        'feedstock_measure': feedstock_measure,
+        'feedstock_amount': feedstock_amount,
+        'unit_numerator': 'dt', 'unit_denominator': 'ac',
+        'source_lon': -87.6, 'source_lat': 41.8,
+        'destination_lon': -87.6, 'destination_lat': 41.8,
+    }])
+
+
+class TestEmissionFactorsEdgeCases:
+
+    def test_empty_production_returns_empty_results(self, ef_config):
+        """EmissionFactors.run() with an empty production frame returns empty results."""
+        from FPEAM.Data import Equipment, Production
+        # build minimal but typed empty frames using the Data subclass
+        equip_df = _make_equipment()
+        prod_df = _make_production()
+        equip = Equipment(df=equip_df, backfill=False)
+        # empty production — one row but wrong feedstock_measure so nothing matches
+        prod = Production(df=_make_production(feedstock_measure='nonexistent'), backfill=False)
+        with EmissionFactors(config=ef_config, equipment=equip, production=prod) as ef:
+            ef.run()
+        assert ef.status == 'complete'
+        assert ef.results is not None
+        assert len(ef.results) == 0
+
+    def test_non_default_feedstock_measure_type_filters_correctly(self, ef_config):
+        """Only rows matching feedstock_measure_type contribute to results."""
+        from FPEAM.Data import Equipment, Production
+        equip = Equipment(df=_make_equipment(), backfill=False)
+        # two rows: one 'harvested', one 'production'
+        mixed = pd.concat([
+            _make_production(feedstock_measure='harvested'),
+            _make_production(feedstock_measure='production', feedstock_amount=999.0),
+        ], ignore_index=True)
+        prod = Production(df=mixed, backfill=False)
+        with EmissionFactors(config=ef_config, equipment=equip, production=prod) as ef:
+            ef.run()
+        # default feedstock_measure_type is 'harvested'
+        # the 999-unit production row should not appear in results
+        assert ef.status == 'complete'
+        assert ef.results is not None
+        # all results should come from the 100-unit row, not 999
+        assert (ef.results['pollutant_amount'] <= 150).all(), \
+            "Expected only harvested-measure rows; production-measure row leaked in"
+
+    def test_run_sets_status_complete_on_success(self, ef_config):
+        """Successful run() sets module status to 'complete'."""
+        from FPEAM.Data import Equipment, Production
+        equip = Equipment(df=_make_equipment(), backfill=False)
+        prod = Production(df=_make_production(), backfill=False)
+        with EmissionFactors(config=ef_config, equipment=equip, production=prod) as ef:
+            ef.run()
+        assert ef.status == 'complete'
+
+    def test_results_have_required_columns(self, ef_config):
+        """Results DataFrame always has the expected output columns."""
+        from FPEAM.Data import Equipment, Production
+        equip = Equipment(df=_make_equipment(), backfill=False)
+        prod = Production(df=_make_production(), backfill=False)
+        with EmissionFactors(config=ef_config, equipment=equip, production=prod) as ef:
+            ef.run()
+        required = {'region_production', 'region_destination', 'feedstock',
+                    'tillage_type', 'module', 'activity', 'resource',
+                    'resource_subtype', 'pollutant', 'pollutant_amount'}
+        assert required.issubset(set(ef.results.columns))
+
+    def test_pollutant_amounts_are_non_negative(self, ef_config):
+        """Emission factors and rates are non-negative so results should be too."""
+        from FPEAM.Data import Equipment, Production
+        equip = Equipment(df=_make_equipment(), backfill=False)
+        prod = Production(df=_make_production(), backfill=False)
+        with EmissionFactors(config=ef_config, equipment=equip, production=prod) as ef:
+            ef.run()
+        assert (ef.results['pollutant_amount'] >= 0).all()

--- a/tests/unit_tests/test_io.py
+++ b/tests/unit_tests/test_io.py
@@ -1,0 +1,47 @@
+"""Tests for FPEAM.IO — load() and load_configs() functions."""
+import os
+import pytest
+import pandas as pd
+
+from FPEAM.IO import load
+
+
+class TestLoad:
+    """Tests for IO.load()."""
+
+    def test_basic_csv(self, tmp_path):
+        """load() reads a well-formed CSV into a DataFrame with typed columns."""
+        csv = tmp_path / 'sample.csv'
+        csv.write_text('feedstock,rate\ncorn grain,1.5\nwheat straw,0.8\n')
+        df = load(str(csv), columns={'feedstock': str, 'rate': float})
+        assert list(df.columns) == ['feedstock', 'rate']
+        assert len(df) == 2
+        assert df['rate'].dtype == float
+
+    def test_missing_file_raises(self):
+        """load() raises FileNotFoundError for a non-existent path."""
+        with pytest.raises((FileNotFoundError, IOError, OSError)):
+            load('/does/not/exist.csv', columns={'col': str})
+
+    def test_missing_columns_raises(self, tmp_path):
+        """load() raises ValueError naming the missing columns."""
+        csv = tmp_path / 'partial.csv'
+        csv.write_text('feedstock,rate\ncorn grain,1.5\n')
+        with pytest.raises(ValueError, match='activity'):
+            load(str(csv), columns={'feedstock': str, 'rate': float, 'activity': str})
+
+    def test_extra_columns_ignored(self, tmp_path):
+        """Columns present in the file but not in 'columns' dict are not loaded."""
+        csv = tmp_path / 'extra.csv'
+        csv.write_text('feedstock,rate,extra_col\ncorn grain,1.5,junk\n')
+        df = load(str(csv), columns={'feedstock': str, 'rate': float})
+        assert 'extra_col' not in df.columns
+        assert len(df) == 1
+
+    def test_nan_handling(self, tmp_path):
+        """load() returns NaN for blank cells in float columns."""
+        csv = tmp_path / 'nulls.csv'
+        csv.write_text('feedstock,rate\ncorn grain,\nwheat straw,0.8\n')
+        df = load(str(csv), columns={'feedstock': str, 'rate': float})
+        assert pd.isna(df.loc[0, 'rate'])
+        assert df.loc[1, 'rate'] == 0.8


### PR DESCRIPTION
Adds test_io.py (5 tests: happy path, missing file, missing cols, extra cols, NaN) and test_emissionfactors_extended.py (5 edge-case tests). Also fixes a pandas 2.x compat bug in IO.load() where the missing-usecols ValueError message changed. 15 tests pass.