### PR TITLE
test+fix: Router/FugitiveDust tests; fix pandas 2.x groupby.prod and scipy deprecation

### DIFF
--- a/src/FPEAM/EngineModules/FugitiveDust.py
+++ b/src/FPEAM/EngineModules/FugitiveDust.py
@@ -137,10 +137,11 @@ class FugitiveDust(Module):
             self.feedstock_loss_factors.supply_chain_stage.isin(['farm gate'])]
 
         # calculate total losses on farm, remove unnecessary columns
-        _loss_factors_farmgate = _loss_factors_farmgate.groupby(['feedstock'],
-                                                                as_index=False)
-        _loss_factors_farmgate = _loss_factors_farmgate.prod()[['feedstock',
-                                                                'dry_matter_remaining']]
+        # select only numeric-compatible columns before .prod() to avoid
+        # pandas 2.x TypeError on string columns
+        _loss_factors_farmgate = _loss_factors_farmgate[['feedstock', 'dry_matter_remaining']]\
+            .groupby(['feedstock'], as_index=False)\
+            .prod()[['feedstock', 'dry_matter_remaining']]
 
         # grab relevant prod data frame - preprocessed in init
         _prod = self.prod_onroad

--- a/src/FPEAM/FPEAM.py
+++ b/src/FPEAM/FPEAM.py
@@ -207,15 +207,16 @@ class FPEAM(object):
                                                                                       'on farm transport'])]
 
         # calculate total remaining fraction by feedstock by multiplying
-        # the remaining fractions
-        _loss_factors = _loss_factors.groupby(['feedstock'],
-                                              as_index=False).prod()[['feedstock',
-                                                                      'dry_matter_remaining']]
+        # the remaining fractions; select numeric columns only to avoid
+        # pandas 2.x TypeError on string columns
+        _loss_factors = _loss_factors[['feedstock', 'dry_matter_remaining']]\
+            .groupby(['feedstock'], as_index=False)\
+            .prod()[['feedstock', 'dry_matter_remaining']]
 
         # calculate total remaining fraction at farm gate
-        _loss_factors_farmgate = _loss_factors_farmgate.groupby(['feedstock'],
-                                                                as_index=False).prod()[['feedstock',
-                                                                                        'dry_matter_remaining']]
+        _loss_factors_farmgate = _loss_factors_farmgate[['feedstock', 'dry_matter_remaining']]\
+            .groupby(['feedstock'], as_index=False)\
+            .prod()[['feedstock', 'dry_matter_remaining']]
 
         # subset the feedstock production df by which feedstock measures
         # will be used in normalizing pollutant amounts

--- a/src/FPEAM/Router.py
+++ b/src/FPEAM/Router.py
@@ -2,7 +2,7 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 from networkx.algorithms.shortest_paths.weighted import bidirectional_dijkstra
-from scipy.spatial import ckdtree
+from scipy.spatial import cKDTree
 
 from FPEAM import utils
 
@@ -23,7 +23,7 @@ class Router(object):
         """
 
         self.node_map = node_map
-        self._btree = ckdtree.cKDTree(np.array(list(zip(self.node_map.x, self.node_map.y))))
+        self._btree = cKDTree(np.array(list(zip(self.node_map.x, self.node_map.y))))
 
         self.edges = edges
 

--- a/tests/unit_tests/test_fugitivedust.py
+++ b/tests/unit_tests/test_fugitivedust.py
@@ -1,0 +1,111 @@
+"""Focused unit tests for FugitiveDust on-farm emissions path."""
+import pytest
+import pandas as pd
+
+from FPEAM.EngineModules.FugitiveDust import FugitiveDust
+from FPEAM.IO import load_configs, _resource_path, CONFIG_FOLDER
+from FPEAM.Data import FeedstockLossFactors, TruckCapacity, Production
+
+
+@pytest.fixture(scope='module')
+def fd_config():
+    return load_configs(_resource_path('%s/run_config.ini' % CONFIG_FOLDER))
+
+
+@pytest.fixture(scope='module')
+def minimal_production():
+    """Single harvested row for corn grain, no router path."""
+    return Production(df=pd.DataFrame([{
+        'feedstock': 'corn grain',
+        'tillage_type': 'conventional tillage',
+        'region_production': '17031',
+        'region_destination': '17031',
+        'equipment_group': 'grp1',
+        'feedstock_measure': 'harvested',
+        'feedstock_amount': 1000.0,
+        'unit_numerator': 'dt',
+        'unit_denominator': 'ac',
+        'source_lon': -87.6298,
+        'source_lat': 41.8781,
+        'destination_lon': -87.6298,
+        'destination_lat': 41.8781,
+        'row_id': 0,
+    }]), backfill=False)
+
+
+@pytest.fixture(scope='module')
+def minimal_loss_factors():
+    return FeedstockLossFactors(df=pd.DataFrame([{
+        'feedstock': 'corn grain',
+        'supply_chain_stage': 'farm gate',
+        'dry_matter_loss': 0.1,
+    }]), backfill=False)
+
+
+@pytest.fixture(scope='module')
+def minimal_truck_capacity():
+    return TruckCapacity(df=pd.DataFrame([{
+        'feedstock': 'corn grain',
+        'truck_capacity': 25.0,
+        'unit_numerator': 'dt',
+        'unit_denominator': 'trip',
+    }]), backfill=False)
+
+
+class TestFugitiveDustOnFarm:
+
+    def test_onfarm_run_returns_pm10_and_pm25(
+        self, fd_config, minimal_production, minimal_loss_factors,
+        minimal_truck_capacity
+    ):
+        """get_onfarm_fugitivedust returns rows for PM10 and PM2.5."""
+        fd = FugitiveDust(
+            config=fd_config,
+            production=minimal_production,
+            feedstock_loss_factors=minimal_loss_factors,
+            truck_capacity=minimal_truck_capacity,
+            vmt_short_haul=20,
+            forestry_feedstock_names=[],
+            router=None,
+            backfill=True,
+        )
+        result = fd.get_onfarm_fugitivedust()
+        assert set(result['pollutant'].unique()) >= {'pm10', 'pm25'}
+
+    def test_onfarm_emissions_positive(
+        self, fd_config, minimal_production, minimal_loss_factors,
+        minimal_truck_capacity
+    ):
+        """On-farm emissions are non-negative for valid inputs."""
+        fd = FugitiveDust(
+            config=fd_config,
+            production=minimal_production,
+            feedstock_loss_factors=minimal_loss_factors,
+            truck_capacity=minimal_truck_capacity,
+            vmt_short_haul=20,
+            forestry_feedstock_names=[],
+            router=None,
+            backfill=True,
+        )
+        result = fd.get_onfarm_fugitivedust()
+        assert (result['pollutant_amount'] >= 0).all()
+
+    def test_run_without_router_completes(
+        self, fd_config, minimal_production, minimal_loss_factors,
+        minimal_truck_capacity
+    ):
+        """run() without a router finishes with status='complete'."""
+        fd = FugitiveDust(
+            config=fd_config,
+            production=minimal_production,
+            feedstock_loss_factors=minimal_loss_factors,
+            truck_capacity=minimal_truck_capacity,
+            vmt_short_haul=20,
+            forestry_feedstock_names=[],
+            router=None,
+            backfill=True,
+        )
+        fd.run()
+        assert fd.status == 'complete'
+        assert fd.results is not None
+        assert len(fd.results) > 0

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -1,0 +1,67 @@
+"""Smoke tests for FPEAM.Router using a small synthetic road graph."""
+import pytest
+import numpy as np
+import pandas as pd
+
+from FPEAM.Router import Router
+
+
+@pytest.fixture(scope='module')
+def small_router():
+    """
+    Four nodes at known coordinates connected by three edges forming a path:
+    node 1 (0,0) -- edge 1 (weight=1000m, county 001) -- node 2 (0,1)
+    node 2 (0,1) -- edge 2 (weight=2000m, county 001) -- node 3 (0,2)
+    node 3 (0,2) -- edge 3 (weight=1000m, county 003) -- node 4 (1,2)
+    """
+    edges = pd.DataFrame([
+        {'edge_id': 1, 'statefp': '17', 'countyfp': '001',
+         'u_of_edge': 1, 'v_of_edge': 2, 'weight': 1000.0, 'fclass': 1},
+        {'edge_id': 2, 'statefp': '17', 'countyfp': '001',
+         'u_of_edge': 2, 'v_of_edge': 3, 'weight': 2000.0, 'fclass': 1},
+        {'edge_id': 3, 'statefp': '17', 'countyfp': '003',
+         'u_of_edge': 3, 'v_of_edge': 4, 'weight': 1000.0, 'fclass': 1},
+    ])
+    node_map = pd.DataFrame([
+        {'node_id': 1, 'x': 0.0, 'y': 0.0},
+        {'node_id': 2, 'x': 0.0, 'y': 1.0},
+        {'node_id': 3, 'x': 0.0, 'y': 2.0},
+        {'node_id': 4, 'x': 1.0, 'y': 2.0},
+    ])
+    return Router(edges=edges, node_map=node_map, memory=None)
+
+
+class TestRouterSmoke:
+
+    def test_get_route_returns_dataframe(self, small_router):
+        """get_route returns a DataFrame with region_transportation, fclass, vmt columns."""
+        result = small_router.get_route(start=(0.0, 0.0), end=(1.0, 2.0))
+        assert isinstance(result, pd.DataFrame)
+        assert set(result.columns) == {'region_transportation', 'fclass', 'vmt'}
+
+    def test_route_covers_both_counties(self, small_router):
+        """Route from node 1 to node 4 passes through county 001 and 003."""
+        result = small_router.get_route(start=(0.0, 0.0), end=(1.0, 2.0))
+        assert '17001' in result['region_transportation'].values
+        assert '17003' in result['region_transportation'].values
+
+    def test_vmt_is_positive(self, small_router):
+        """All VMT values are positive (weight / 1000 * km_per_mile_conversion)."""
+        result = small_router.get_route(start=(0.0, 0.0), end=(1.0, 2.0))
+        assert (result['vmt'] > 0).all()
+
+    def test_vmt_county_001_approx(self, small_router):
+        """
+        County 001 carries edges 1+2: total weight 3000m → ~1.863 miles.
+        Tolerance is loose because node snapping may vary.
+        """
+        result = small_router.get_route(start=(0.0, 0.0), end=(1.0, 2.0))
+        vmt_001 = result.loc[result['region_transportation'] == '17001', 'vmt'].sum()
+        expected = (3000.0 / 1000.0) * 0.621371
+        assert abs(vmt_001 - expected) < 0.01
+
+    def test_nearest_node_fallback(self, small_router):
+        """Start coordinates that don't land exactly on a node snap to the nearest."""
+        # (0.01, 0.01) is closest to node 1 (0, 0)
+        result = small_router.get_route(start=(0.01, 0.01), end=(0.99, 2.01))
+        assert not result.empty


### PR DESCRIPTION
Adds 5 Router smoke tests, 3 FugitiveDust on-farm tests. Fixes found in the process: Router.py ckdtree deprecation, FugitiveDust.get_onroad_fugitivedust and FPEAM.collect groupby.prod TypeError on string columns (pandas 2.x). 23 tests pass.