### PR TITLE
refactor: P2 quality — safe tempdir cleanup, eval/inplace removal in tested paths

### DIFF
--- a/src/FPEAM/EngineModules/EmissionFactors.py
+++ b/src/FPEAM/EngineModules/EmissionFactors.py
@@ -41,7 +41,9 @@ class EmissionFactors(Module):
 
         # calculate overall rate as the product of the resource subtype
         # distributions and the subtype-specific emission factors
-        _factors_merge.eval('overall_rate = distribution * rate', inplace=True)
+        _factors_merge = _factors_merge.assign(
+            overall_rate=_factors_merge['distribution'] * _factors_merge['rate']
+        )
 
         # sum emissions factors within unique combinations of
         # feedstock-activity-resource-pollutant to generate overall factors
@@ -80,8 +82,7 @@ class EmissionFactors(Module):
             .merge(self.overall_factors[_factors_columns], on=['feedstock', 'resource'])
 
         # calculate emissions
-        _df.eval('pollutant_amount = overall_rate * feedstock_amount * rate',
-                 inplace=True)
+        _df = _df.assign(pollutant_amount=_df['overall_rate'] * _df['feedstock_amount'] * _df['rate'])
 
         # add column to identify the module
         _df['module'] = 'emission factors'

--- a/src/FPEAM/EngineModules/FugitiveDust.py
+++ b/src/FPEAM/EngineModules/FugitiveDust.py
@@ -93,7 +93,7 @@ class FugitiveDust(Module):
         _df = self.prod_onfarm.merge(self.fugitive_dust_factors, on=self.prod_idx)
 
         # calculate fugitive dust
-        _df.eval('pollutant_amount = feedstock_amount * rate', inplace=True)
+        _df = _df.assign(pollutant_amount=_df['feedstock_amount'] * _df['rate'])
 
         # add column to identify module
         _df['module'] = 'fugitive dust'

--- a/src/FPEAM/FPEAM.py
+++ b/src/FPEAM/FPEAM.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 import tempfile
 from collections.abc import Iterable
@@ -47,7 +46,8 @@ class FPEAM(object):
 
         self.router = None
 
-        self._temp_dir = tempfile.mkdtemp()
+        self._temp_dir_obj = tempfile.TemporaryDirectory()
+        self._temp_dir = self._temp_dir_obj.name
 
         self.memory = Memory(location=self._temp_dir)
 
@@ -444,7 +444,10 @@ class FPEAM(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        shutil.rmtree(self._temp_dir)
+        try:
+            self._temp_dir_obj.cleanup()
+        except Exception:
+            LOGGER.warning('failed to clean up temp directory: %s' % self._temp_dir)
 
         # process exceptions
         if exc_type is not None:


### PR DESCRIPTION
Replaces tempfile.mkdtemp+shutil.rmtree with TemporaryDirectory for safe cleanup on Windows. Removes eval(inplace=True) in EmissionFactors and FugitiveDust (tested paths only). 23 tests pass.