### PR TITLE
fix+docs+refactor: remaining P0/P2/P3 tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ moves_db_pass = <your password>   # never use a default here
 - Source layout: `src/FPEAM/` (package root), `src/FPEAM/EngineModules/` (MOVES, NONROAD, EmissionFactors, FugitiveDust).
 - CI runs on push/PR to `dev` and `master` via `.github/workflows/test.yml`.
 - Contributing: branch off `dev`, open a PR targeting `dev`.
+- Architecture overview: [`docs/architecture.md`](docs/architecture.md)
+- Output file reference: [`docs/outputs.md`](docs/outputs.md)
+
+## GUI (legacy)
+
+`src/FPEAM/gui/` contains a PyQt5 graphical interface (`AllModuleTab.py`) developed for Windows. It is **not tested or exercised by CI** and should be considered unmaintained. All current functionality is accessible through the CLI or Python API.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# FPEAM Architecture
+
+## Overview
+
+FPEAM calculates spatially explicit emissions inventories from biomass feedstock production and transportation. It is structured as a central orchestrator (`FPEAM` class) that assembles shared inputs, configures independent emission modules, runs them, and merges results.
+
+## Package layout
+
+```
+src/FPEAM/
+├── __init__.py             # Public surface re-exports: FPEAM, Data, IO, utils, EngineModules
+├── FPEAM.py                # Orchestrator class
+├── Data.py                 # Data container classes (subclass pd.DataFrame)
+├── IO.py                   # CSV loading, config loading, resource path helper
+├── utils.py                # Logger factory, configure_logging(), config validator, filepath validator
+├── Router.py               # Shortest-path routing on a county road graph (networkx + scipy)
+├── Interfaces.py           # Stub interfaces for external models (InMAP, BenMAP, Polysys)
+├── Figures.py              # Stub figure module
+├── EngineModules/
+│   ├── __init__.py         # Re-exports all four modules
+│   ├── EmissionFactors.py  # Static emission-factor calculations
+│   ├── FugitiveDust.py     # On-farm and on-road particulate matter
+│   ├── MOVES.py            # EPA MOVES wrapper (on-road transportation)
+│   └── NONROAD.py          # EPA NONROAD wrapper (on-farm equipment)
+├── configs/
+│   ├── *.spec              # Annotated config schema (configobj format)
+│   └── *.ini               # Default config values
+├── data/
+│   ├── equipment/          # Equipment use rate tables
+│   ├── inputs/             # Reference data (emission factors, silt, FIPS maps, …)
+│   ├── outputs/            # Example/golden outputs (tracked in git)
+│   └── production/         # Example production scenarios
+├── gui/                    # Legacy PyQt5 GUI (see GUI section below)
+└── scripts/
+    └── fpeam.py            # CLI entrypoint
+```
+
+## Data flow
+
+```
+run_config.ini
+      │
+      ▼
+ FPEAM.__init__
+  ├── load Equipment, Production, FeedstockLossFactors, TruckCapacity
+  ├── (optionally) build Router from transportation graph + node locations
+  └── configure each requested module (EmissionFactors, FugitiveDust, MOVES, NONROAD)
+         │
+         ▼
+ FPEAM.run()
+  ├── EmissionFactors.run()   → results DataFrame (lb pollutant / row)
+  ├── FugitiveDust.run()      → results DataFrame
+  ├── MOVES.run()             → results DataFrame (requires MOVES + MySQL)
+  └── NONROAD.run()           → results DataFrame (requires NONROAD + MySQL)
+         │
+         ▼
+ FPEAM.collect()
+  ├── stack module results
+  ├── apply feedstock loss factors to production quantities
+  └── merge with production to enable normalisation
+         │
+         ▼
+ FPEAM.summarize()
+  └── write per-region, per-module, and normalised CSVs to project_path
+```
+
+## Key classes
+
+### `Data` (`Data.py`)
+
+Thin subclass of `pd.DataFrame`. Each concrete subclass (`Equipment`, `Production`, `EmissionFactor`, `ResourceDistribution`, etc.) declares a `COLUMNS` tuple that drives type-casting and optional backfill.  
+`__init__` validates after load; raises `RuntimeError` naming the subclass and source on failure.
+
+### `Module` (`EngineModules/Module.py`)
+
+Abstract base for all engine modules. Handles config loading (merges defaults from bundled `.ini`, validates against bundled `.spec`), unit conversions dict, and a standard `run()`/`save()`/`__enter__`/`__exit__` contract.
+
+### `FPEAM` (`FPEAM.py`)
+
+Orchestrator. Owns shared datasets, the joblib memory cache (temp dir), and the router. `collect()` is the most important post-processing step: it merges module results with production data and applies loss factors to derive delivered feedstock quantities.
+
+### `Router` (`Router.py`)
+
+Wraps a `networkx.Graph` built from a county road edge table. `get_route(start, end)` finds the shortest path between two lat/lon points (nearest-node snapping via `scipy.spatial.cKDTree`) and returns VMT by county and road class.
+
+## Configuration system
+
+Each module uses `configobj` for hierarchical INI-style configs.
+
+1. Default values come from the bundled `configs/<module>.ini`.
+2. The schema (type, range, default) is defined in `configs/<module>.spec`.
+3. User-supplied config values override defaults via `ConfigObj.merge()`.
+4. Validation runs at module `__init__` time; errors are logged and raise `ConfigObjError`.
+
+The orchestrator reads `run_config.ini` (schema in `run_config.spec`) plus one optional INI per module.
+
+## External dependencies (MOVES and NONROAD)
+
+MOVES 3/5 and NONROAD are Windows-only EPA models that must be installed separately. FPEAM:
+
+1. Reads from and writes to a local MySQL database used by MOVES.
+2. Generates input XML files for each MOVES run (one per county/year).
+3. Invokes MOVES via a `.bat` file and reads results back from MySQL.
+4. NONROAD follows a similar pattern with flat-file inputs/outputs.
+
+Running FPEAM with only `EmissionFactors` and/or `FugitiveDust` does **not** require MOVES, NONROAD, or MySQL.
+
+## GUI (legacy)
+
+`src/FPEAM/gui/` contains a PyQt5 GUI (`AllModuleTab.py`) that was developed for Windows and is not exercised by tests or CI. It is present for reference but should be considered unmaintained. Use the CLI (`fpeam` entrypoint) or Python API for current workflows.
+
+## Testing
+
+Tests live in `tests/unit_tests/`. Run with:
+
+```bash
+pixi run test
+# or
+PYTHONPATH=src python -m pytest tests/
+```
+
+CI runs on push/PR to `dev` and `master` via `.github/workflows/test.yml`.
+
+Current coverage: `test_data`, `test_io`, `test_emissionfactors`, `test_emissionfactors_extended`, `test_router`, `test_fugitivedust`.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,0 +1,89 @@
+# FPEAM Outputs
+
+FPEAM writes several CSV files to the `project_path` directory defined in `run_config.ini`. All filenames are prefixed with `<scenario_name>` (the `scenario_name` key in `run_config.ini`).
+
+## Files written by `FPEAM.run()` + `FPEAM.summarize()`
+
+### `<scenario_name>_raw.csv`
+
+Written by the CLI entrypoint (`scripts/fpeam.py`) immediately after `FPEAM.run()`.  
+This is the full merged result from `FPEAM.collect()`.
+
+**Columns** (varies by which modules are run):
+
+| Column | Description |
+|---|---|
+| `region_production` | 5-digit FIPS of the production county |
+| `region_destination` | 5-digit FIPS of the biorefinery county (if applicable) |
+| `region_transportation` | 5-digit FIPS of a county along the transport route (FugitiveDust/MOVES) |
+| `feedstock` | Feedstock name (e.g. `corn grain`, `switchgrass`) |
+| `tillage_type` | Tillage type (e.g. `conventional tillage`, `no tillage`) |
+| `module` | Name of the module that produced the row |
+| `activity` | Activity that generated the emission (e.g. `chemical application`) |
+| `resource` | Input resource (e.g. `nitrogen`, `herbicide`) |
+| `resource_subtype` | Specific form of the resource (e.g. `anhydrous ammonia`) |
+| `pollutant` | Pollutant name (e.g. `nh3`, `voc`, `pm10`, `pm25`) |
+| `pollutant_amount` | Emission mass in pounds |
+| `unit_numerator` | Always `lb pollutant` |
+| `unit_denominator` | Always `county-year` |
+| `feedstock_measure` | How the feedstock quantity is measured (`harvested`, `production`, `at farm gate`, `at biorefinery`) |
+| `feedstock_amount` | Feedstock quantity |
+| `feedstock_unit_numerator` | Feedstock mass unit numerator |
+| `feedstock_unit_denominator` | Feedstock mass unit denominator |
+
+---
+
+### `<scenario_name>_total_emissions_by_production_region.csv`
+
+Emissions grouped by `feedstock`, `tillage_type`, `region_production`, and `pollutant`. Used for county-level mapping.
+
+**Columns:** `feedstock`, `tillage_type`, `region_production`, `pollutant`, `pollutant_amount`, `unit_numerator` (`lb pollutant`), `unit_denominator` (`county-year`).
+
+---
+
+### `<scenario_name>_normalized_total_emissions_by_production_region.csv`
+
+Same as above but normalised by feedstock amount so the values are in `lb pollutant / dt feedstock` (or equivalent).
+
+**Additional columns:** `feedstock_measure`, `feedstock_amount`, `feedstock_unit_numerator`, `normalized_pollutant_amount`, `normalized_pollutant_unit_numerator`, `normalized_pollutant_unit_denominator`.
+
+---
+
+### `<scenario_name>_transportation_emissions_by_region.csv`
+
+Only written when at least one module produces `region_transportation` data (FugitiveDust on-road or MOVES). Grouped by `feedstock`, `tillage_type`, `region_transportation`, `pollutant`.
+
+**Columns:** `feedstock`, `tillage_type`, `region_transportation`, `pollutant`, `pollutant_amount`.
+
+---
+
+### `<scenario_name>_total_emissions_by_module.csv`
+
+Emissions grouped by `feedstock`, `tillage_type`, `module`, `pollutant`. Useful for comparing module contributions.
+
+**Columns:** `feedstock`, `tillage_type`, `module`, `pollutant`, `pollutant_amount`, `unit_numerator`, `unit_denominator`.
+
+---
+
+### `<scenario_name>_county_inmap.shp` (optional)
+
+Written only when `inmap_county_export = True` in `fpeam.ini`. A shapefile that joins county geometries with aggregated pollutant amounts per county, formatted for InMAP input.
+
+---
+
+## Files written by MOVES module
+
+MOVES writes intermediate XML and CSV files to `moves_datafiles_path` during each county run. These are working files and should not be treated as final outputs. The MOVES output database is the authoritative intermediate store.
+
+## Files written by NONROAD module
+
+NONROAD writes population, allocation, and options files to `nonroad_datafiles_path`. Like MOVES, these are working files, not final deliverables.
+
+## Reproducibility
+
+To reproduce an output:
+
+1. Keep the config files (`.ini` for each module + `run_config.ini`).
+2. Keep the input data files referenced in the configs (equipment CSV, production CSV, emission factors CSV, resource distribution CSV).
+3. Record the software version (`FPEAM.__version__` or `git rev-parse HEAD`).
+4. For MOVES/NONROAD results: record the MOVES/NONROAD version and the MySQL database snapshot used.

--- a/src/FPEAM/Data.py
+++ b/src/FPEAM/Data.py
@@ -63,8 +63,8 @@ class Data(pd.DataFrame):
             # count the total values
             _count_total = self[column].__len__()
 
-            # fill the missing values with zeros
-            self[column].fillna(value, inplace=True)
+            # fill the missing values
+            self[column] = self[column].fillna(value)
 
             # log a warning with the number of missing values
             LOGGER.warning('%s of %s data values in %s.%s were backfilled as %s' %

--- a/src/FPEAM/EngineModules/EmissionFactors.py
+++ b/src/FPEAM/EngineModules/EmissionFactors.py
@@ -27,6 +27,22 @@ class EmissionFactors(Module):
         self.emission_factors = EmissionFactor(fpath=self.config.get('emission_factors'),
                                                backfill=backfill)
 
+        # Check that emission factor units are the expected lb/lb contract.
+        # Other units are not currently supported; warn loudly rather than
+        # silently produce wrong results.
+        _unexpected_units = self.emission_factors[
+            (self.emission_factors['unit_numerator'].str.lower() != 'pound') |
+            (self.emission_factors['unit_denominator'].str.lower() != 'pound')
+        ]
+        if not _unexpected_units.empty:
+            LOGGER.warning(
+                'EmissionFactors assumes lb_pollutant/lb_resource units but '
+                '%d rows have different units: %s',
+                len(_unexpected_units),
+                _unexpected_units[['resource', 'resource_subtype',
+                                   'unit_numerator', 'unit_denominator']].to_dict('records'),
+            )
+
         # Resource subtype distribution, Units: unit-less fraction
         self.resource_distribution = ResourceDistribution(fpath=self.config.get('resource_distribution'),
                                                           backfill=backfill)

--- a/src/FPEAM/EngineModules/MOVES.py
+++ b/src/FPEAM/EngineModules/MOVES.py
@@ -1,4 +1,3 @@
-import pdb
 import os
 
 import numpy as np
@@ -2225,13 +2224,15 @@ class MOVES(Module):
                 LOGGER.debug('import file: %s' % self.xmlimport_filename)
 
                 # import data and log output
-                command = 'cd {moves_path} & setenv.bat & ' \
-                          'java -Xmx512M ' \
-                          '-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" ' \
-                          'gov.epa.otaq.moves.master.commandline.MOVESCommandLine' \
-                          ' -i {import_file}' \
-                          ''.format(moves_path=self.moves_path,
-                                    import_file=self.xmlimport_filename)
+                command = (
+                    r'cd {moves_path} & setenv.bat & '
+                    r'java -Xmx512M '
+                    r'-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;'
+                    r'libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;'
+                    r'libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" '
+                    r'gov.epa.otaq.moves.master.commandline.MOVESCommandLine'
+                    r' -i {import_file}'
+                ).format(moves_path=self.moves_path, import_file=self.xmlimport_filename)
                 os.system(command)  # @TODO: need to capture output, catch errors
 
                 # fix I/M Program flag
@@ -2256,12 +2257,15 @@ class MOVES(Module):
                 LOGGER.info('running MOVES for FIPS: %s' % _fips)
                 LOGGER.debug('runspec file: %s' % self.runspec_filename)
 
-                command = 'cd {moves_folder} & setenv.bat & ' \
-                          'java -Xmx512M ' \
-                          '-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" ' \
-                          'gov.epa.otaq.moves.master.commandline.MOVESCommandLine ' \
-                          '-r {run_moves}'.format(moves_folder=self.moves_path,
-                                                  run_moves=self.runspec_filename)
+                command = (
+                    r'cd {moves_folder} & setenv.bat & '
+                    r'java -Xmx512M '
+                    r'-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;'
+                    r'libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;'
+                    r'libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" '
+                    r'gov.epa.otaq.moves.master.commandline.MOVESCommandLine '
+                    r'-r {run_moves}'
+                ).format(moves_folder=self.moves_path, run_moves=self.runspec_filename)
 
                 os.system(command)  # @TODO: need to capture output, catch errors
 

--- a/src/FPEAM/__init__.py
+++ b/src/FPEAM/__init__.py
@@ -4,23 +4,9 @@ from . import Data
 from . import Figures
 from . import IO
 from . import Interfaces
-# from .FPEAM import Modules
-# from . import Modules
 from . import EngineModules
 from . import utils
 from .FPEAM import FPEAM
 
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-# Set default logging handler to avoid "No handler found" warnings.
-logging.getLogger(__name__).addHandler(NullHandler())
-
-try:
-    basestring
-except NameError:
-    basestring = str
+# Suppress "No handlers found" warning for library usage.
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/FPEAM/utils.py
+++ b/src/FPEAM/utils.py
@@ -17,6 +17,29 @@ def logger(name='FPEAM'):
     return logging.getLogger(name=name)
 
 
+def configure_logging(level='INFO', fmt=None):
+    """
+    Configure root logging for FPEAM applications.
+
+    Call this once from scripts or CLI entrypoints; library callers should
+    configure logging themselves.  Idempotent: adding a second StreamHandler
+    is guarded by checking whether any handlers already exist on the root.
+
+    :param level: [str] logging level name, e.g. 'DEBUG', 'INFO', 'WARNING'
+    :param fmt: [str|None] log format string; defaults to a compact timestamped format
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        return  # already configured
+
+    if fmt is None:
+        fmt = '%(asctime)s %(levelname)-8s %(name)s: %(message)s'
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+    root.addHandler(handler)
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+
 def validate_config(config, spec):
     """
     Perform validation against <config> using <spec>, returning type-casted ConfigObj, any errors,


### PR DESCRIPTION
Removes pdb import (MOVES.py), cleans Python 2 shims from __init__.py, adds configure_logging() helper, adds units consistency warning in EmissionFactors, fixes MOVES.py SyntaxWarnings on Windows paths. Creates docs/architecture.md and docs/outputs.md, updates README with links and GUI legacy note. 23 tests pass.