### PR TITLE
feat(EmissionFactors): region-keyed emission factors with national fallback

### DIFF
--- a/src/FPEAM/Data.py
+++ b/src/FPEAM/Data.py
@@ -200,6 +200,14 @@ class EmissionFactor(Data):
     def __init__(self, df=None, fpath=None,
                  columns={d['name']: d['type'] for d in COLUMNS for k in d.keys()},
                  backfill=True):
+        # If loading from file, include 'region' when the CSV has that column
+        # so region-keyed factors are carried through unchanged.
+        if fpath is not None and 'region' not in columns:
+            import pandas as _pd
+            _header = _pd.read_csv(fpath, nrows=0).columns.tolist()
+            if 'region' in _header:
+                columns = dict(columns)
+                columns['region'] = str
         super(EmissionFactor, self).__init__(df=df, fpath=fpath, columns=columns,
                                              backfill=backfill)
 

--- a/src/FPEAM/EngineModules/EmissionFactors.py
+++ b/src/FPEAM/EngineModules/EmissionFactors.py
@@ -2,11 +2,19 @@ from .Module import Module
 from .. import utils
 from ..Data import (EmissionFactor, ResourceDistribution)
 
+import pandas as pd
+
 LOGGER = utils.logger(name=__name__)
 
 
 class EmissionFactors(Module):
-    """Base class to manage execution of pollutants calculated from emission factors"""
+    """Calculates pollutants from static (optionally region-keyed) emission factors.
+
+    If the emission_factors CSV contains a ``region`` column, the module uses
+    region-specific rates for matching counties and falls back to national rows
+    (where ``region`` is blank/NaN) for counties that have no regional override.
+    When no ``region`` column is present the behavior is identical to prior versions.
+    """
 
     def __init__(self, config, equipment, production, backfill=True, **kvals):
         """
@@ -28,8 +36,6 @@ class EmissionFactors(Module):
                                                backfill=backfill)
 
         # Check that emission factor units are the expected lb/lb contract.
-        # Other units are not currently supported; warn loudly rather than
-        # silently produce wrong results.
         _unexpected_units = self.emission_factors[
             (self.emission_factors['unit_numerator'].str.lower() != 'pound') |
             (self.emission_factors['unit_denominator'].str.lower() != 'pound')
@@ -50,73 +56,100 @@ class EmissionFactors(Module):
         # Selector for the crop amount that scales emission factors
         self.feedstock_measure_type = self.config.get('feedstock_measure_type')
 
+        # Detect whether region-keyed factors are present
+        self._has_region_factors = 'region' in self.emission_factors.columns
+
         # merge emissions factors and resource subtype distribution
-        # dataframes by matching resource and resource subtype
         _factors_merge = self.resource_distribution.merge(self.emission_factors,
                                                           on=['resource', 'resource_subtype'])
 
-        # calculate overall rate as the product of the resource subtype
-        # distributions and the subtype-specific emission factors
         _factors_merge = _factors_merge.assign(
             overall_rate=_factors_merge['distribution'] * _factors_merge['rate']
         )
 
-        # sum emissions factors within unique combinations of
-        # feedstock-activity-resource-pollutant to generate overall factors
-        # that will convert resource mass to pollutant mass
-        self.overall_factors = _factors_merge.groupby(['feedstock',
-                                                       'activity',
-                                                       'resource',
-                                                       'resource_subtype',
-                                                       'pollutant'],
-                                                      as_index=False).sum()
+        # group columns depend on whether a region dimension is present
+        _group_cols = ['feedstock', 'activity', 'resource', 'resource_subtype', 'pollutant']
+        if self._has_region_factors:
+            _group_cols.append('region')
+
+        self.overall_factors = _factors_merge.groupby(_group_cols, as_index=False,
+                                                       dropna=False).sum()
+
+        if self._has_region_factors:
+            LOGGER.info('EmissionFactors loaded with region-keyed factors; '
+                        'national rows (region=NaN) will be used as fallback.')
 
     def get_emissions(self):
         """
-        Calculate all emissions from <resource> for which a subtype
-        distribution and emissions factors are provided.
+        Calculate all emissions. When region-keyed factors are loaded, region-specific
+        rates take precedence and national rates cover any remaining regions.
 
         :return: [DataFrame] pollutant amounts
         """
 
-        # create column selectors
         _idx = ['feedstock', 'tillage_type', 'equipment_group']
-        _prod_columns = _idx + ['region_production',
-                                'region_destination',
-                                'feedstock_amount']
+        _prod_columns = _idx + ['region_production', 'region_destination', 'feedstock_amount']
         _equip_columns = _idx + ['rate', 'resource']
         _factors_columns = ['feedstock', 'activity', 'resource',
                             'resource_subtype', 'overall_rate', 'pollutant']
 
-        # create row selectors
         _prod_rows = self.production.feedstock_measure == self.feedstock_measure_type
 
-        # combine production and equipment and overall factors
-        _df = self.production[_prod_rows][_prod_columns].merge(self.equipment[_equip_columns],
-                                                               on=_idx,
-                                                               suffixes=['_prod', '_equip'])\
-            .merge(self.overall_factors[_factors_columns], on=['feedstock', 'resource'])
+        # base merged frame: production × equipment
+        _base = (self.production[_prod_rows][_prod_columns]
+                 .merge(self.equipment[_equip_columns], on=_idx, suffixes=['_prod', '_equip']))
 
-        # calculate emissions
+        if self._has_region_factors:
+            _regional_cols = _factors_columns + ['region']
+
+            # rows with a non-null region value
+            _regional_factors = self.overall_factors[
+                self.overall_factors['region'].notna()
+            ][_regional_cols].copy()
+
+            # rows without a region value (national defaults)
+            _national_factors = self.overall_factors[
+                self.overall_factors['region'].isna()
+            ][_factors_columns]
+
+            # apply regional factors (inner join on region_production == region)
+            _df_regional = _base.merge(
+                _regional_factors,
+                left_on=['feedstock', 'resource', 'region_production'],
+                right_on=['feedstock', 'resource', 'region'],
+            )
+            _df_regional = _df_regional.drop(columns=['region'])
+
+            # apply national factors only to rows not covered by regional factors
+            _covered = _df_regional[['feedstock', 'tillage_type', 'equipment_group',
+                                     'region_production', 'region_destination',
+                                     'feedstock_amount']].drop_duplicates()
+            _base_national = _base.merge(
+                _covered,
+                on=['feedstock', 'tillage_type', 'equipment_group',
+                    'region_production', 'region_destination', 'feedstock_amount'],
+                how='left',
+                indicator=True,
+            )
+            _base_national = _base_national[_base_national['_merge'] == 'left_only'].drop(columns=['_merge'])
+
+            _df_national = _base_national.merge(_national_factors, on=['feedstock', 'resource'])
+
+            _df = pd.concat([_df_regional, _df_national], ignore_index=True, sort=False)
+        else:
+            _df = _base.merge(self.overall_factors[_factors_columns], on=['feedstock', 'resource'])
+
         _df = _df.assign(pollutant_amount=_df['overall_rate'] * _df['feedstock_amount'] * _df['rate'])
-
-        # add column to identify the module
         _df['module'] = 'emission factors'
 
-        # clean up DataFrame
         _df = _df[['region_production', 'region_destination', 'feedstock',
                    'tillage_type', 'module', 'activity', 'resource',
-                   'resource_subtype', 'pollutant',
-                   'pollutant_amount']]
+                   'resource_subtype', 'pollutant', 'pollutant_amount']]
 
         return _df
 
     def run(self):
-        """
-        Execute all calculations.
-
-        :return:
-        """
+        """Execute all calculations."""
 
         _results = None
         _status = self.status

--- a/tests/unit_tests/test_region_emission_factors.py
+++ b/tests/unit_tests/test_region_emission_factors.py
@@ -1,0 +1,161 @@
+"""Tests for region-keyed emission factors (Phase 1 of dynamic EF roadmap).
+
+Covers:
+- National-only factors produce identical results to pre-region behavior (regression).
+- Region-specific factors override national defaults for matching counties.
+- Unknown regions fall back to national defaults.
+- Mixed CSVs (some regions, some national) work correctly.
+"""
+import io
+import pytest
+import pandas as pd
+
+from FPEAM.EngineModules import EmissionFactors
+from FPEAM.Data import Equipment, Production, EmissionFactor, ResourceDistribution
+from FPEAM.IO import load_configs, _resource_path, CONFIG_FOLDER
+
+
+@pytest.fixture(scope='module')
+def ef_config():
+    return load_configs(_resource_path('%s/run_config.ini' % CONFIG_FOLDER))
+
+
+def _equipment():
+    return Equipment(df=pd.DataFrame([{
+        'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+        'equipment_group': 'grp1', 'rotation_year': 1,
+        'activity': 'chemical application', 'equipment_name': 'tractor',
+        'equipment_horsepower': 100.0, 'resource': 'nitrogen', 'rate': 1.0,
+        'unit_numerator': 'lb', 'unit_denominator': 'ac',
+    }]), backfill=False)
+
+
+def _production_two_regions():
+    return Production(df=pd.DataFrame([
+        {
+            'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+            'region_production': 'REGION_A', 'region_destination': 'REGION_A',
+            'equipment_group': 'grp1', 'feedstock_measure': 'harvested',
+            'feedstock_amount': 100.0, 'unit_numerator': 'dt', 'unit_denominator': 'ac',
+            'source_lon': -87.6, 'source_lat': 41.8,
+            'destination_lon': -87.6, 'destination_lat': 41.8,
+        },
+        {
+            'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+            'region_production': 'REGION_B', 'region_destination': 'REGION_B',
+            'equipment_group': 'grp1', 'feedstock_measure': 'harvested',
+            'feedstock_amount': 200.0, 'unit_numerator': 'dt', 'unit_denominator': 'ac',
+            'source_lon': -95.0, 'source_lat': 40.0,
+            'destination_lon': -95.0, 'destination_lat': 40.0,
+        },
+    ]), backfill=False)
+
+
+# Minimal factors CSV content (national, no region column)
+_NATIONAL_FACTORS_CSV = """\
+resource,resource_subtype,activity,pollutant,rate,unit_numerator,unit_denominator
+nitrogen,anhydrous ammonia,chemical application,nh3,0.04,pound,pound
+"""
+
+# Regional factors CSV: REGION_A gets a higher rate; REGION_B falls back to national
+_REGIONAL_FACTORS_CSV = """\
+resource,resource_subtype,activity,pollutant,rate,unit_numerator,unit_denominator,region
+nitrogen,anhydrous ammonia,chemical application,nh3,0.04,pound,pound,
+nitrogen,anhydrous ammonia,chemical application,nh3,0.10,pound,pound,REGION_A
+"""
+
+_DISTRIBUTION_CSV = """\
+feedstock,resource,resource_subtype,distribution
+corn grain,nitrogen,anhydrous ammonia,1.0
+"""
+
+
+def _make_ef_from_csv(config, equip, prod, factors_csv, dist_csv=_DISTRIBUTION_CSV):
+    """Construct EmissionFactors from in-memory CSV strings via temporary files."""
+    import tempfile, os
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f_ef:
+        f_ef.write(factors_csv)
+        ef_path = f_ef.name
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f_rd:
+        f_rd.write(dist_csv)
+        rd_path = f_rd.name
+
+    # Patch config to point at temp files
+    from configobj import ConfigObj
+    cfg = ConfigObj(config)
+    cfg['emission_factors'] = ef_path
+    cfg['resource_distribution'] = rd_path
+
+    try:
+        ef = EmissionFactors(config=cfg, equipment=equip, production=prod)
+        ef.run()
+        return ef
+    finally:
+        os.unlink(ef_path)
+        os.unlink(rd_path)
+
+
+class TestNationalOnlyFactors:
+
+    def test_national_regression(self, ef_config):
+        """National-only CSV: behavior identical to pre-region implementation."""
+        equip = _equipment()
+        prod = _production_two_regions()
+        ef = _make_ef_from_csv(ef_config, equip, prod, _NATIONAL_FACTORS_CSV)
+        assert ef.status == 'complete'
+        # Both regions get the same national rate (0.04 lb/lb × 1 lb/unit × feedstock)
+        assert len(ef.results) > 0
+        assert not ef._has_region_factors
+        results_by_region = ef.results.groupby('region_production')['pollutant_amount'].sum()
+        # region B has 2× the feedstock amount so 2× the emissions
+        assert abs(results_by_region['REGION_B'] / results_by_region['REGION_A'] - 2.0) < 1e-9
+
+
+class TestRegionKeyedFactors:
+
+    def test_region_flag_detected(self, ef_config):
+        """EmissionFactors detects region column in factors CSV."""
+        equip = _equipment()
+        prod = _production_two_regions()
+        ef = _make_ef_from_csv(ef_config, equip, prod, _REGIONAL_FACTORS_CSV)
+        assert ef._has_region_factors
+
+    def test_regional_rate_applied_to_region_a(self, ef_config):
+        """REGION_A gets the higher regional rate (0.10), not the national rate (0.04)."""
+        equip = _equipment()
+        prod = _production_two_regions()
+        ef = _make_ef_from_csv(ef_config, equip, prod, _REGIONAL_FACTORS_CSV)
+        assert ef.status == 'complete'
+        results_a = ef.results[ef.results['region_production'] == 'REGION_A']['pollutant_amount'].sum()
+        # REGION_A: 100 feedstock × 1 lb/unit × 0.10 rate
+        assert abs(results_a - 10.0) < 1e-9
+
+    def test_national_fallback_for_region_b(self, ef_config):
+        """REGION_B (no regional override) falls back to national rate (0.04)."""
+        equip = _equipment()
+        prod = _production_two_regions()
+        ef = _make_ef_from_csv(ef_config, equip, prod, _REGIONAL_FACTORS_CSV)
+        results_b = ef.results[ef.results['region_production'] == 'REGION_B']['pollutant_amount'].sum()
+        # REGION_B: 200 feedstock × 1 lb/unit × 0.04 rate
+        assert abs(results_b - 8.0) < 1e-9
+
+    def test_required_columns_present(self, ef_config):
+        """Results have standard output columns regardless of regional mode."""
+        equip = _equipment()
+        prod = _production_two_regions()
+        ef = _make_ef_from_csv(ef_config, equip, prod, _REGIONAL_FACTORS_CSV)
+        required = {'region_production', 'region_destination', 'feedstock',
+                    'tillage_type', 'module', 'activity', 'resource',
+                    'resource_subtype', 'pollutant', 'pollutant_amount'}
+        assert required.issubset(set(ef.results.columns))
+        assert 'region' not in ef.results.columns  # internal column must not leak out
+
+    def test_no_duplicate_rows_for_region_a(self, ef_config):
+        """Region A should not also appear with the national rate."""
+        equip = _equipment()
+        prod = _production_two_regions()
+        ef = _make_ef_from_csv(ef_config, equip, prod, _REGIONAL_FACTORS_CSV)
+        rows_a = ef.results[ef.results['region_production'] == 'REGION_A']
+        # With one feedstock measure row and one resource/subtype there should be exactly one result row
+        assert len(rows_a) == 1


### PR DESCRIPTION
Phase 1 of the dynamic EF roadmap. EmissionFactor CSV may now include an optional region column. Region-specific rates take precedence; national rows (blank region) serve as fallback for unmatched counties. Existing CSVs unchanged. 29 tests pass.