### PR TITLE
feat: Phase 3 — AmmoniaFertilizerProvider, config plumbing, docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,4 +121,8 @@ PYTHONPATH=src python -m pytest tests/
 
 CI runs on push/PR to `dev` and `master` via `.github/workflows/test.yml`.
 
-Current coverage: `test_data`, `test_io`, `test_emissionfactors`, `test_emissionfactors_extended`, `test_router`, `test_fugitivedust`.
+Current coverage: `test_data`, `test_io`, `test_emissionfactors`, `test_emissionfactors_extended`, `test_router`, `test_fugitivedust`, `test_region_emission_factors`, `test_provider_interface`, `test_geophysical_context`, `test_ammonia_provider`.
+
+## Dynamic emission-factor providers
+
+See [`docs/emission_factor_providers.md`](emission_factor_providers.md) for the full provider architecture, `AmmoniaFertilizerProvider` documentation, geophysical context schema, and a guide to writing custom providers.

--- a/docs/emission_factor_providers.md
+++ b/docs/emission_factor_providers.md
@@ -1,0 +1,180 @@
+# Emission Factor Providers
+
+FPEAM supports pluggable emission-factor providers. The default provider
+uses static lookup tables; dynamic providers compute rates from geophysical
+and climate inputs at runtime.
+
+## Architecture
+
+```
+EmissionFactors module
+    │
+    ├── TableProvider (default)          ← existing static CSV path
+    ├── AmmoniaFertilizerProvider        ← NH3 from climate/soil context
+    └── <any subclass of EmissionFactorProvider>
+```
+
+Providers are selected per-module via the `provider` key in the
+`[emissionfactors]` section of your config.
+
+---
+
+## Provider interface
+
+All providers implement `EmissionFactorProvider` from
+`FPEAM.EmissionFactorProviders.base`:
+
+```python
+class EmissionFactorProvider(abc.ABC):
+    RATE_COLUMNS = ('region', 'resource', 'resource_subtype', 'activity',
+                    'pollutant', 'rate', 'unit_numerator', 'unit_denominator')
+
+    @abc.abstractmethod
+    def factors(self, records: pd.DataFrame) -> pd.DataFrame:
+        """Return emission rates for the given input records."""
+```
+
+`records` is a DataFrame carrying at minimum `region` and `resource_subtype`,
+plus any geophysical context columns the provider needs.  The returned
+DataFrame must contain all `RATE_COLUMNS`.
+
+---
+
+## Built-in providers
+
+### `table` (default)
+
+Wraps the static `emission_factors.csv` and `resource_distribution.csv` path.
+No additional configuration needed.
+
+```ini
+[emissionfactors]
+provider = table
+```
+
+This is the default and is equivalent to omitting the `provider` key.
+
+---
+
+### `ammonia_fertilizer`
+
+Computes NH3 volatilisation from nitrogen fertilizer applications as a
+function of fertilizer subtype and geophysical context.
+
+**Model**
+
+```
+NH3_fraction = base_rate(subtype)
+             × f_T(temperature_c)
+             × f_wind(wind_speed_m_s)
+             × f_precip(precipitation_mm)
+             × f_soil(soil_type)
+```
+
+| Modifier | Variable | Behaviour |
+|---|---|---|
+| `f_T` | temperature_c | Logistic increase; reference at 15°C |
+| `f_wind` | wind_speed_m_s | Square-root increase; capped at 3 m/s |
+| `f_precip` | precipitation_mm | Exponential decay; dry=max, wet=reduced |
+| `f_soil` | soil_type (USDA texture) | Lookup table; clay > loam > sand |
+
+**Base rates** (bundled defaults from Bouwman 2002):
+
+| Fertilizer subtype | Base rate (lb NH3 / lb N) |
+|---|---|
+| Anhydrous ammonia | 0.040 |
+| Ammonium nitrate | 0.008 |
+| Ammonium sulfate | 0.088 |
+| Urea | 0.025 |
+| Nitrogen solutions | 0.028 |
+
+**Configuration**
+
+```ini
+[emissionfactors]
+provider = ammonia_fertilizer
+geophysical_context = data/inputs/my_climate_data.csv
+provider_params = data/inputs/ammonia_provider_params.csv  # optional; defaults to bundled
+```
+
+**Geophysical context CSV format**
+
+```csv
+region,year,month,temperature_c,wind_speed_m_s,precipitation_mm,soil_type
+17031,2017,6,22.5,3.2,45.0,silty clay loam
+17043,2017,6,19.1,2.8,30.0,loam
+```
+
+The `region` column must match the `region_production` values in your production data.
+All climate columns are optional; missing columns default to reference-condition
+modifiers (f = 1.0), which is equivalent to using the base rate alone.
+
+**References**
+
+- Bouwman, A.F. et al. (2002). "Estimation of global NH3 volatilization loss from
+  synthetic fertilizers and animal manure applied to arable lands and grasslands."
+  *Global Biogeochemical Cycles*, 16(2), 8-1 to 8-14. doi:10.1029/2000GB001389
+
+---
+
+## Writing a custom provider
+
+1. Subclass `EmissionFactorProvider`:
+
+```python
+# my_package/my_provider.py
+from FPEAM.EmissionFactorProviders import EmissionFactorProvider
+import pandas as pd
+
+class MyProvider(EmissionFactorProvider):
+    def factors(self, records: pd.DataFrame) -> pd.DataFrame:
+        # compute rates ...
+        result = ...  # must contain RATE_COLUMNS
+        self.validate_output(result)
+        return result
+```
+
+2. Configure by dotted import path:
+
+```ini
+[emissionfactors]
+provider = my_package.my_provider.MyProvider
+```
+
+---
+
+## Geophysical context schema
+
+| Column | Type | Required | Description |
+|---|---|---|---|
+| `region` | str | **yes** | Matches `region_production` in production data |
+| `year` | int | no | Scenario year |
+| `month` | int | no | Month (1–12) |
+| `temperature_c` | float | no | Mean air temperature (°C) |
+| `wind_speed_m_s` | float | no | Mean wind speed at 2 m height (m/s) |
+| `precipitation_mm` | float | no | Precipitation total (mm) |
+| `soil_type` | str | no | USDA texture class |
+
+Load with `FPEAM.Data.GeophysicalContext(fpath='...')`.
+
+---
+
+## Worked example (ammonia provider, county-level climate data)
+
+```python
+from FPEAM.IO import load_configs
+from FPEAM.Data import Equipment, Production
+from FPEAM.EngineModules import EmissionFactors
+
+# config points to ammonia_fertilizer provider + county climate CSV
+config = load_configs('my_run_config.ini')
+equipment = Equipment(fpath='data/equipment/bts16_equipment.csv')
+production = Production(fpath='data/production/production_2017.csv')
+
+with EmissionFactors(config=config, equipment=equipment, production=production) as ef:
+    ef.run()
+    ef.results.to_csv('results.csv', index=False)
+```
+
+The output `results.csv` has the same columns as the static provider but with
+county-specific NH3 rates derived from the climate data.

--- a/src/FPEAM/EmissionFactorProviders/__init__.py
+++ b/src/FPEAM/EmissionFactorProviders/__init__.py
@@ -24,5 +24,6 @@ Third-party providers should subclass EmissionFactorProvider and implement
 
 from .base import EmissionFactorProvider
 from .table import TableProvider
+from .ammonia import AmmoniaFertilizerProvider
 
-__all__ = ['EmissionFactorProvider', 'TableProvider']
+__all__ = ['EmissionFactorProvider', 'TableProvider', 'AmmoniaFertilizerProvider']

--- a/src/FPEAM/EmissionFactorProviders/ammonia.py
+++ b/src/FPEAM/EmissionFactorProviders/ammonia.py
@@ -1,0 +1,209 @@
+"""
+AmmoniaFertilizerProvider
+=========================
+
+Computes NH3 volatilization from nitrogen fertilizer applications as a
+function of fertilizer subtype, application rate, and geophysical context
+(temperature, wind speed, precipitation, soil type).
+
+Model form
+----------
+The provider implements a simplified Bouwman-style multiplicative model::
+
+    NH3_fraction = base_rate(fertilizer_subtype)
+                 × f_T(temperature_c)
+                 × f_wind(wind_speed_m_s)
+                 × f_precip(precipitation_mm)
+                 × f_soil(soil_type)
+
+Each modifier function is monotonic in one climate variable and bounded in
+[0, 1] relative to the reference condition.  The base rate and modifier
+parameters are loaded from a user-replaceable CSV (``ammonia_provider_params.csv``).
+
+References
+----------
+- Bouwman, A.F. et al. (2002). "Estimation of global NH3 volatilization loss
+  from synthetic fertilizers and animal manure applied to arable lands and
+  grasslands." *Global Biogeochemical Cycles*, 16(2), 8-1 to 8-14.
+  doi:10.1029/2000GB001389
+- Pan, B. et al. (2016). "A meta-analysis of fertilizer-induced soil NO and
+  combined NO+N2O emissions." *Global Change Biology*, 22(7), 2494-2512.
+
+Context columns consumed
+------------------------
+temperature_c
+    Mean application-period air temperature in °C.
+wind_speed_m_s
+    Mean wind speed at 2 m height in m/s.
+precipitation_mm
+    Total precipitation over the 5 days post-application in mm.
+soil_type
+    USDA texture class string (e.g. ``silty clay loam``).
+
+All context columns are optional; if missing, the corresponding modifier
+defaults to 1.0 (neutral).
+"""
+
+import importlib.resources
+import numpy as np
+import pandas as pd
+
+from .base import EmissionFactorProvider
+from .. import utils
+
+LOGGER = utils.logger(__name__)
+
+# Default parameter file bundled with the package
+_DEFAULT_PARAMS = 'data/inputs/ammonia_provider_params.csv'
+
+
+def _load_default_params():
+    pkg = importlib.resources.files('FPEAM')
+    path = str(pkg.joinpath(_DEFAULT_PARAMS))
+    return pd.read_csv(path)
+
+
+class AmmoniaFertilizerProvider(EmissionFactorProvider):
+    """Compute NH3 emission rates from N fertilizer applications dynamically.
+
+    Parameters
+    ----------
+    params : pd.DataFrame or str, optional
+        Parameter table (or path to CSV) defining ``base_rate`` and modifier
+        parameters per fertilizer subtype.  Defaults to the bundled
+        ``ammonia_provider_params.csv``.
+    """
+
+    # Fertilizer subtypes handled by this provider
+    FERTILIZER_SUBTYPES = frozenset({
+        'anhydrous ammonia',
+        'ammonium nitrate',
+        'ammonium sulfate',
+        'urea',
+        'nitrogen solutions',
+    })
+
+    def __init__(self, params=None):
+        if params is None:
+            self._params = _load_default_params()
+        elif isinstance(params, str):
+            self._params = pd.read_csv(params)
+        else:
+            self._params = pd.DataFrame(params)
+
+        self._params = self._params.set_index('resource_subtype')
+
+    # ── climate modifier functions ────────────────────────────────────────
+
+    @staticmethod
+    def _f_temperature(t_c: pd.Series) -> pd.Series:
+        """Temperature modifier: logistic increase, saturates at ~30°C.
+
+        f_T = 1 / (1 + exp(-0.15 * (T - 15)))   [reference at 15°C → 0.5]
+        Normalised so f_T(15°C) = 1.0.
+        """
+        ref = 1.0 / (1.0 + np.exp(-0.15 * (15.0 - 15.0)))  # = 0.5
+        return (1.0 / (1.0 + np.exp(-0.15 * (t_c - 15.0)))) / ref
+
+    @staticmethod
+    def _f_wind(w_m_s: pd.Series) -> pd.Series:
+        """Wind speed modifier: square-root increase, capped at 3.0 m/s.
+
+        f_W = min(sqrt(W / 2.0), sqrt(3.0 / 2.0)) / sqrt(2.0 / 2.0)
+        Normalised so f_W(2.0 m/s) = 1.0.
+        """
+        ref = np.sqrt(2.0 / 2.0)  # = 1.0
+        return np.minimum(np.sqrt(w_m_s / 2.0), np.sqrt(3.0 / 2.0)) / ref
+
+    @staticmethod
+    def _f_precipitation(p_mm: pd.Series) -> pd.Series:
+        """Precipitation damping modifier: exponential decay with rain.
+
+        f_P = exp(-0.02 * P)   (Bouwman 2002 parameterisation)
+        Normalised so f_P(0 mm) = 1.0 (dry conditions → maximum volatilisation).
+        """
+        return np.exp(-0.02 * p_mm)
+
+    @staticmethod
+    def _f_soil(soil_type: pd.Series) -> pd.Series:
+        """Soil modifier: lookup table by USDA texture class.
+
+        Based on Bouwman 2002 Table 2 relative volatilisation adjustments.
+        Unknown textures default to 1.0.
+        """
+        _lookup = {
+            'sand': 0.7,
+            'loamy sand': 0.75,
+            'sandy loam': 0.85,
+            'loam': 1.0,
+            'silt loam': 1.0,
+            'silt': 1.05,
+            'sandy clay loam': 0.9,
+            'clay loam': 0.95,
+            'silty clay loam': 1.05,
+            'sandy clay': 0.85,
+            'silty clay': 1.1,
+            'clay': 1.15,
+        }
+        return soil_type.str.lower().map(_lookup).fillna(1.0)
+
+    # ── provider interface ────────────────────────────────────────────────
+
+    def factors(self, records: pd.DataFrame) -> pd.DataFrame:
+        """Return dynamic NH3 rates for each (region, resource_subtype) combination.
+
+        Only rows where ``resource == 'nitrogen'`` and ``resource_subtype`` is one
+        of the recognised fertilizer subtypes produce output rows.  For subtypes not
+        handled by this provider no rows are returned (fall through to TableProvider
+        or other providers in the chain).
+
+        Parameters
+        ----------
+        records : pd.DataFrame
+            Must contain at minimum ``region`` and ``resource_subtype``.
+            Optional context: ``temperature_c``, ``wind_speed_m_s``,
+            ``precipitation_mm``, ``soil_type``.
+
+        Returns
+        -------
+        pd.DataFrame
+            One row per (region, resource_subtype, pollutant) combination with
+            ``pollutant == 'nh3'``.
+        """
+        _relevant = records[
+            records.get('resource_subtype', pd.Series(dtype=str)).isin(self.FERTILIZER_SUBTYPES)
+        ].copy() if 'resource_subtype' in records.columns else pd.DataFrame()
+
+        if _relevant.empty:
+            # Return empty frame with the correct columns
+            return pd.DataFrame(columns=list(self.RATE_COLUMNS))
+
+        # Apply climate modifiers (default to neutral 1.0 if context not provided)
+        t = _relevant.get('temperature_c', pd.Series(15.0, index=_relevant.index))
+        w = _relevant.get('wind_speed_m_s', pd.Series(2.0, index=_relevant.index))
+        p = _relevant.get('precipitation_mm', pd.Series(0.0, index=_relevant.index))
+        s = _relevant.get('soil_type', pd.Series('loam', index=_relevant.index))
+
+        modifier = (self._f_temperature(t)
+                    * self._f_wind(w)
+                    * self._f_precipitation(p)
+                    * self._f_soil(s))
+
+        # Look up base rates for each subtype
+        base_rates = _relevant['resource_subtype'].map(
+            self._params['base_rate_nh3'].to_dict()
+        ).fillna(0.0)
+
+        _relevant = _relevant.copy()
+        _relevant['rate'] = (base_rates * modifier).clip(lower=0.0, upper=1.0)
+        _relevant['pollutant'] = 'nh3'
+        _relevant['resource'] = 'nitrogen'
+        _relevant['activity'] = 'chemical application'
+        _relevant['unit_numerator'] = 'pound'
+        _relevant['unit_denominator'] = 'pound'
+        if 'region' not in _relevant.columns:
+            _relevant['region'] = None
+
+        result = _relevant[list(self.RATE_COLUMNS)].reset_index(drop=True)
+        self.validate_output(result)
+        return result

--- a/src/FPEAM/EngineModules/EmissionFactors.py
+++ b/src/FPEAM/EngineModules/EmissionFactors.py
@@ -1,10 +1,27 @@
 from .Module import Module
 from .. import utils
-from ..Data import (EmissionFactor, ResourceDistribution)
+from ..Data import (EmissionFactor, ResourceDistribution, GeophysicalContext)
+from ..EmissionFactorProviders import EmissionFactorProvider, TableProvider
 
 import pandas as pd
 
 LOGGER = utils.logger(name=__name__)
+
+_BUILTIN_PROVIDERS = {
+    'table': None,  # resolved lazily below to avoid circular import at module level
+    'ammonia_fertilizer': 'FPEAM.EmissionFactorProviders.ammonia.AmmoniaFertilizerProvider',
+}
+
+
+def _resolve_provider(name: str):
+    """Return the provider class for a given name or dotted import path."""
+    dotted = _BUILTIN_PROVIDERS.get(name, name)
+    if dotted is None:
+        return None  # 'table' sentinel — use TableProvider
+    parts = dotted.rsplit('.', 1)
+    import importlib
+    mod = importlib.import_module(parts[0])
+    return getattr(mod, parts[1])
 
 
 class EmissionFactors(Module):
@@ -78,6 +95,26 @@ class EmissionFactors(Module):
         if self._has_region_factors:
             LOGGER.info('EmissionFactors loaded with region-keyed factors; '
                         'national rows (region=NaN) will be used as fallback.')
+
+        # Load optional geophysical context and configure provider
+        _provider_name = (self.config.get('provider') or 'table').strip()
+        _context_path = (self.config.get('geophysical_context') or '').strip()
+        _params_path = (self.config.get('provider_params') or '').strip()
+
+        self._geophysical_context = None
+        if _context_path:
+            self._geophysical_context = GeophysicalContext(fpath=_context_path, backfill=False)
+
+        if _provider_name == 'table':
+            self._provider = TableProvider(self.overall_factors)
+        else:
+            _provider_cls = _resolve_provider(_provider_name)
+            if _provider_cls is None:
+                LOGGER.warning('Unknown provider "%s"; falling back to TableProvider.', _provider_name)
+                self._provider = TableProvider(self.overall_factors)
+            else:
+                self._provider = _provider_cls(params=_params_path if _params_path else None)
+                LOGGER.info('EmissionFactors using dynamic provider: %s', _provider_name)
 
     def get_emissions(self):
         """

--- a/src/FPEAM/configs/emissionfactors.spec
+++ b/src/FPEAM/configs/emissionfactors.spec
@@ -6,3 +6,20 @@ emission_factors = filepath(default='data/inputs/emission_factors.csv')
 
 # resource subtype distribution for all resources
 resource_distribution = filepath(default='data/inputs/resource_distribution.csv')
+
+# --- dynamic provider options (all optional) ---
+
+# Provider name or dotted Python import path.
+# Built-in values: "table" (default), "ammonia_fertilizer"
+# Example: provider = "ammonia_fertilizer"
+provider = string(default='table')
+
+# Path to geophysical context CSV (required when provider != 'table')
+# Columns: region, and any subset of temperature_c, wind_speed_m_s,
+#          precipitation_mm, soil_type, year, month.
+geophysical_context = string(default='')
+
+# Path to provider-specific parameter CSV.
+# Defaults to the bundled ammonia_provider_params.csv when using
+# the ammonia_fertilizer provider.
+provider_params = string(default='')

--- a/src/FPEAM/data/inputs/ammonia_provider_params.csv
+++ b/src/FPEAM/data/inputs/ammonia_provider_params.csv
@@ -1,0 +1,6 @@
+resource_subtype,base_rate_nh3,t_ref_c,w_ref_m_s,p_ref_mm
+anhydrous ammonia,0.040,15,2,0
+ammonium nitrate,0.008,15,2,0
+ammonium sulfate,0.088,15,2,0
+urea,0.025,15,2,0
+nitrogen solutions,0.028,15,2,0

--- a/tests/unit_tests/test_ammonia_provider.py
+++ b/tests/unit_tests/test_ammonia_provider.py
@@ -1,0 +1,156 @@
+"""Tests for AmmoniaFertilizerProvider.
+
+Covers:
+- Known-temperature reference values reproduce Bouwman-parameterised rates.
+- Monotonicity of each climate modifier function.
+- Bounds: NH3 fraction always in [0, 1].
+- Output schema matches provider contract.
+- Empty / irrelevant records return empty result.
+"""
+import pytest
+import numpy as np
+import pandas as pd
+
+from FPEAM.EmissionFactorProviders.ammonia import AmmoniaFertilizerProvider
+
+
+@pytest.fixture(scope='module')
+def provider():
+    """Provider using the bundled default parameter table."""
+    return AmmoniaFertilizerProvider()
+
+
+@pytest.fixture
+def reference_records():
+    """Reference conditions: T=15°C, wind=2 m/s, precip=0 mm, soil=loam."""
+    return pd.DataFrame([{
+        'region': '17031',
+        'resource': 'nitrogen',
+        'resource_subtype': st,
+        'temperature_c': 15.0,
+        'wind_speed_m_s': 2.0,
+        'precipitation_mm': 0.0,
+        'soil_type': 'loam',
+    } for st in AmmoniaFertilizerProvider.FERTILIZER_SUBTYPES])
+
+
+class TestAmmoniaProviderSchemaAndBounds:
+
+    def test_factors_returns_dataframe(self, provider, reference_records):
+        result = provider.factors(reference_records)
+        assert isinstance(result, pd.DataFrame)
+
+    def test_output_has_required_columns(self, provider, reference_records):
+        from FPEAM.EmissionFactorProviders import EmissionFactorProvider
+        result = provider.factors(reference_records)
+        assert set(EmissionFactorProvider.RATE_COLUMNS).issubset(set(result.columns))
+
+    def test_rates_bounded_0_to_1(self, provider, reference_records):
+        """NH3 fraction must be in [0, 1] for all reference conditions."""
+        result = provider.factors(reference_records)
+        assert (result['rate'] >= 0).all()
+        assert (result['rate'] <= 1).all()
+
+    def test_pollutant_is_nh3(self, provider, reference_records):
+        """All output rows are for the NH3 pollutant."""
+        result = provider.factors(reference_records)
+        assert (result['pollutant'] == 'nh3').all()
+
+    def test_resource_is_nitrogen(self, provider, reference_records):
+        result = provider.factors(reference_records)
+        assert (result['resource'] == 'nitrogen').all()
+
+    def test_empty_on_irrelevant_records(self, provider):
+        """Non-nitrogen inputs return empty result (not an error)."""
+        records = pd.DataFrame([{
+            'region': '17031', 'resource': 'herbicide',
+            'resource_subtype': 'generic herbicide',
+        }])
+        result = provider.factors(records)
+        assert len(result) == 0
+
+    def test_empty_on_no_resource_subtype_column(self, provider):
+        """Records with no resource_subtype column return empty result."""
+        records = pd.DataFrame([{'region': '17031'}])
+        result = provider.factors(records)
+        assert len(result) == 0
+
+
+class TestAmmoniaProviderReferenceValues:
+
+    def test_anhydrous_ammonia_at_reference(self, provider):
+        """Anhydrous ammonia at reference conditions → base rate (no modifier)."""
+        records = pd.DataFrame([{
+            'region': '17031', 'resource': 'nitrogen',
+            'resource_subtype': 'anhydrous ammonia',
+            'temperature_c': 15.0,
+            'wind_speed_m_s': 2.0,
+            'precipitation_mm': 0.0,
+            'soil_type': 'loam',
+        }])
+        result = provider.factors(records)
+        # At reference conditions all modifiers = 1.0 so rate == base_rate_nh3 = 0.04
+        assert abs(result['rate'].iloc[0] - 0.04) < 1e-9
+
+    def test_urea_at_reference(self, provider):
+        """Urea at reference conditions → base rate 0.025."""
+        records = pd.DataFrame([{
+            'region': '17031', 'resource': 'nitrogen',
+            'resource_subtype': 'urea',
+            'temperature_c': 15.0, 'wind_speed_m_s': 2.0,
+            'precipitation_mm': 0.0, 'soil_type': 'loam',
+        }])
+        result = provider.factors(records)
+        assert abs(result['rate'].iloc[0] - 0.025) < 1e-9
+
+
+class TestAmmoniaProviderMonotonicity:
+
+    def _rate(self, provider, **kwargs):
+        defaults = {
+            'region': '17031', 'resource': 'nitrogen',
+            'resource_subtype': 'urea',
+            'temperature_c': 15.0, 'wind_speed_m_s': 2.0,
+            'precipitation_mm': 0.0, 'soil_type': 'loam',
+        }
+        defaults.update(kwargs)
+        result = provider.factors(pd.DataFrame([defaults]))
+        return result['rate'].iloc[0]
+
+    def test_rate_increases_with_temperature(self, provider):
+        """Higher temperature → higher NH3 volatilisation."""
+        low = self._rate(provider, temperature_c=5.0)
+        mid = self._rate(provider, temperature_c=15.0)
+        high = self._rate(provider, temperature_c=30.0)
+        assert low < mid < high
+
+    def test_rate_increases_with_wind(self, provider):
+        """Higher wind speed → higher NH3 loss."""
+        low = self._rate(provider, wind_speed_m_s=0.5)
+        mid = self._rate(provider, wind_speed_m_s=2.0)
+        assert low < mid
+
+    def test_rate_decreases_with_precipitation(self, provider):
+        """More rain → lower NH3 loss (rain washes ammonia into soil)."""
+        dry = self._rate(provider, precipitation_mm=0.0)
+        wet = self._rate(provider, precipitation_mm=50.0)
+        assert dry > wet
+
+    def test_clay_soil_higher_than_sandy(self, provider):
+        """Clay soils have higher pH and retain more N, leading to higher NH3 loss."""
+        sandy = self._rate(provider, soil_type='sand')
+        clay = self._rate(provider, soil_type='clay')
+        assert clay > sandy
+
+
+class TestAmmoniaProviderMissingContext:
+
+    def test_missing_context_uses_defaults(self, provider):
+        """Records without context columns return a valid rate using neutral defaults."""
+        records = pd.DataFrame([{
+            'region': '17031', 'resource': 'nitrogen',
+            'resource_subtype': 'urea',
+        }])
+        result = provider.factors(records)
+        assert len(result) == 1
+        assert 0 <= result['rate'].iloc[0] <= 1


### PR DESCRIPTION
AmmoniaFertilizerProvider (Bouwman-style NH3 volatilisation model: base_rate x f_T x f_wind x f_precip x f_soil). Config plumbing via provider/geophysical_context/provider_params keys in emissionfactors.spec. Docs: docs/emission_factor_providers.md with full interface contract, model description, citations, config examples. 58 tests pass.