### PR TITLE
fix: adversarial audit — 7 correctness and quality fixes

### DIFF
--- a/src/FPEAM/EmissionFactorProviders/ammonia.py
+++ b/src/FPEAM/EmissionFactorProviders/ammonia.py
@@ -60,7 +60,7 @@ _DEFAULT_PARAMS = 'data/inputs/ammonia_provider_params.csv'
 def _load_default_params():
     pkg = importlib.resources.files('FPEAM')
     path = str(pkg.joinpath(_DEFAULT_PARAMS))
-    return pd.read_csv(path)
+    return pd.read_csv(path, comment='#')
 
 
 class AmmoniaFertilizerProvider(EmissionFactorProvider):
@@ -109,11 +109,15 @@ class AmmoniaFertilizerProvider(EmissionFactorProvider):
     def _f_wind(w_m_s: pd.Series) -> pd.Series:
         """Wind speed modifier: square-root increase, capped at 3.0 m/s.
 
-        f_W = min(sqrt(W / 2.0), sqrt(3.0 / 2.0)) / sqrt(2.0 / 2.0)
+        f_W = min(sqrt(max(W, 0) / 2.0), sqrt(3.0 / 2.0)) / sqrt(2.0 / 2.0)
         Normalised so f_W(2.0 m/s) = 1.0.
+
+        Negative wind speeds are physically impossible; they are clamped to 0
+        rather than propagating NaN.
         """
         ref = np.sqrt(2.0 / 2.0)  # = 1.0
-        return np.minimum(np.sqrt(w_m_s / 2.0), np.sqrt(3.0 / 2.0)) / ref
+        w_safe = w_m_s.clip(lower=0.0)
+        return np.minimum(np.sqrt(w_safe / 2.0), np.sqrt(3.0 / 2.0)) / ref
 
     @staticmethod
     def _f_precipitation(p_mm: pd.Series) -> pd.Series:
@@ -178,11 +182,22 @@ class AmmoniaFertilizerProvider(EmissionFactorProvider):
             # Return empty frame with the correct columns
             return pd.DataFrame(columns=list(self.RATE_COLUMNS))
 
-        # Apply climate modifiers (default to neutral 1.0 if context not provided)
+        # Apply climate modifiers (default to neutral conditions when context is absent).
+        # Default reference conditions match the Bouwman 2002 parameterisation:
+        # T=15°C, wind=2 m/s, precip=0 mm (maximum volatilisation scenario),
+        # loam soil.  Users providing a geophysical_context CSV override these defaults.
+        # NOTE: precip=0 (dry) produces the MAXIMUM rate; this is conservative
+        # (over-estimates volatilisation when actual precipitation is unknown).
         t = _relevant.get('temperature_c', pd.Series(15.0, index=_relevant.index))
         w = _relevant.get('wind_speed_m_s', pd.Series(2.0, index=_relevant.index))
         p = _relevant.get('precipitation_mm', pd.Series(0.0, index=_relevant.index))
         s = _relevant.get('soil_type', pd.Series('loam', index=_relevant.index))
+
+        if 'precipitation_mm' not in _relevant.columns:
+            LOGGER.debug(
+                'AmmoniaFertilizerProvider: precipitation_mm not in records; '
+                'using 0 mm (maximum volatilisation / conservative estimate).'
+            )
 
         modifier = (self._f_temperature(t)
                     * self._f_wind(w)

--- a/src/FPEAM/EngineModules/EmissionFactors.py
+++ b/src/FPEAM/EngineModules/EmissionFactors.py
@@ -115,6 +115,14 @@ class EmissionFactors(Module):
             else:
                 self._provider = _provider_cls(params=_params_path if _params_path else None)
                 LOGGER.info('EmissionFactors using dynamic provider: %s', _provider_name)
+                raise NotImplementedError(
+                    'Dynamic provider "%s" is configured but the provider → '
+                    'get_emissions() wiring is not yet complete.  '
+                    'The geophysical context must be joined onto the '
+                    'production×equipment records before passing to '
+                    'provider.factors().  Remove this error when that wiring '
+                    'is implemented.' % _provider_name
+                )
 
     def get_emissions(self):
         """
@@ -157,18 +165,11 @@ class EmissionFactors(Module):
             )
             _df_regional = _df_regional.drop(columns=['region'])
 
-            # apply national factors only to rows not covered by regional factors
-            _covered = _df_regional[['feedstock', 'tillage_type', 'equipment_group',
-                                     'region_production', 'region_destination',
-                                     'feedstock_amount']].drop_duplicates()
-            _base_national = _base.merge(
-                _covered,
-                on=['feedstock', 'tillage_type', 'equipment_group',
-                    'region_production', 'region_destination', 'feedstock_amount'],
-                how='left',
-                indicator=True,
-            )
-            _base_national = _base_national[_base_national['_merge'] == 'left_only'].drop(columns=['_merge'])
+            # apply national factors only to production regions NOT covered by
+            # a regional override.  Use the set of matched region_production
+            # values rather than a float-equality merge on feedstock_amount.
+            _covered_regions = set(_df_regional['region_production'].unique())
+            _base_national = _base[~_base['region_production'].isin(_covered_regions)]
 
             _df_national = _base_national.merge(_national_factors, on=['feedstock', 'resource'])
 

--- a/src/FPEAM/EngineModules/MOVES.py
+++ b/src/FPEAM/EngineModules/MOVES.py
@@ -17,6 +17,21 @@ LOGGER = utils.logger(name=__name__)
 
 _IS_WINDOWS = platform.system() == 'Windows'
 
+# Cache Homebrew prefix at import time (Linux/macOS only) so we avoid
+# shelling out to `brew` on every MOVES county run.
+def _get_homebrew_prefix():
+    _env = os.environ.get('HOMEBREW_PREFIX')
+    if _env:
+        return _env
+    if not _IS_WINDOWS:
+        try:
+            return subprocess.check_output(['brew', '--prefix'], text=True).strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+    return ''
+
+_HOMEBREW_PREFIX = _get_homebrew_prefix()
+
 
 def _build_macos_classpath(moves_home):
     """Build a Unix classpath string from the MOVES source tree.
@@ -88,25 +103,17 @@ def _run_moves_command(flag, mrs_file, moves_home, moves_path, timeout=3600):
         If the MOVES process exits with a non-zero return code.
     """
     if _IS_WINDOWS:
-        # Windows: delegate to the existing batch-file approach via cmd
-        if flag == '-i':
-            cmd = (
-                r'cd {path} & setenv.bat & '
-                r'java -Xmx512M '
-                r'-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;'
-                r'libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;'
-                r'libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" '
-                r'gov.epa.otaq.moves.master.commandline.MOVESCommandLine {flag} {file}'
-            ).format(path=moves_path, flag=flag, file=mrs_file)
-        else:
-            cmd = (
-                r'cd {path} & setenv.bat & '
-                r'java -Xmx512M '
-                r'-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;'
-                r'libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;'
-                r'libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" '
-                r'gov.epa.otaq.moves.master.commandline.MOVESCommandLine {flag} {file}'
-            ).format(path=moves_path, flag=flag, file=mrs_file)
+        # Windows: delegate to the existing batch-file approach via cmd.
+        # Both import (-i) and run (-r) use the same classpath string; the
+        # flag and file differ.
+        cmd = (
+            r'cd {path} & setenv.bat & '
+            r'java -Xmx512M '
+            r'-cp "jre\bin;ant\bin;libs;libs\poi;libs\poi\commons-codec-1.5.jar;'
+            r'libs\commons-lang-2.2.jar;libs\commons-io-2.11.0.jar;'
+            r'libs\mysql-connector-java-5.1.17-bin.jar;libs\abbot;%PATH%" '
+            r'gov.epa.otaq.moves.master.commandline.MOVESCommandLine {flag} {file}'
+        ).format(path=moves_path, flag=flag, file=mrs_file)
         ret = os.system(cmd)
         if ret != 0:
             raise subprocess.CalledProcessError(ret, cmd)
@@ -114,11 +121,10 @@ def _run_moves_command(flag, mrs_file, moves_home, moves_path, timeout=3600):
         # macOS / Linux: use subprocess with the build.xml classpath
         cp = _build_macos_classpath(moves_home)
 
-        # Set up environment: ensure JAVA_HOME and Homebrew PATH are present
+        # Set up environment: ensure JAVA_HOME and Homebrew PATH are present.
+        # Use the module-level cached prefix to avoid shelling out per county.
         env = os.environ.copy()
-        homebrew_prefix = subprocess.check_output(
-            ['brew', '--prefix'], text=True
-        ).strip() if not env.get('HOMEBREW_PREFIX') else env['HOMEBREW_PREFIX']
+        homebrew_prefix = _HOMEBREW_PREFIX
         java_home = env.get(
             'JAVA_HOME',
             os.path.join(homebrew_prefix,

--- a/src/FPEAM/FPEAM.py
+++ b/src/FPEAM/FPEAM.py
@@ -189,22 +189,38 @@ class FPEAM(object):
         """
 
         _df_modules = pd.DataFrame()
-        _prod = self.production
+        # Operate on a copy so self.production is not mutated by column deletions
+        # and renames that follow. Without this copy, calling collect() a second
+        # time (or accessing self.production after run()) raises KeyError.
+        _prod = self.production.copy()
 
         # preprocess the feedstock loss factor dataset to obtain factors
-        # that can be used to calculate delivered feedstock amounts
-        _loss_factors = self.feedstock_loss_factors
+        # that can be used to calculate delivered feedstock amounts.
+        # Work on a copy so self.feedstock_loss_factors is not mutated.
+        _loss_factors = self.feedstock_loss_factors.copy()
 
         # turn the loss factors into remaining fraction
-        _loss_factors.eval('dry_matter_remaining = 1 - dry_matter_loss',
-                           inplace=True)
+        _loss_factors = _loss_factors.assign(
+            dry_matter_remaining=1 - _loss_factors['dry_matter_loss']
+        )
 
         # calculate separate data frame including only loss factors associated
-        # with on-farm activities
-        _loss_factors_farmgate = _loss_factors[_loss_factors.supply_chain_stage.isin(['harvest',
-                                                                                      'field treatment',
-                                                                                      'field drying',
-                                                                                      'on farm transport'])]
+        # with on-farm (pre-farm-gate) activities.
+        # The bundled feedstock_loss_factors.csv uses the stage name 'farm gate'
+        # for all on-farm losses (harvest, field drying, on-farm transport combined
+        # into one aggregate row per feedstock). Older stage names like 'harvest',
+        # 'field treatment', 'field drying', 'on farm transport' may appear in
+        # user-supplied files with finer granularity; both conventions are supported.
+        _farmgate_stages = {
+            'farm gate',           # bundled default — single aggregate row
+            'harvest',             # finer granularity alternative
+            'field treatment',
+            'field drying',
+            'on farm transport',
+        }
+        _loss_factors_farmgate = _loss_factors[
+            _loss_factors.supply_chain_stage.isin(_farmgate_stages)
+        ]
 
         # calculate total remaining fraction by feedstock by multiplying
         # the remaining fractions; select numeric columns only to avoid

--- a/src/FPEAM/Router.py
+++ b/src/FPEAM/Router.py
@@ -58,7 +58,7 @@ class Router(object):
         _end_point_idx = self._btree.query(_end_point, k=1)[1]
         to_node = self.node_map.loc[_end_point_idx, 'node_id']
 
-        if not (from_node and to_node):
+        if from_node is None or to_node is None:
             raise ValueError('start or end node is undefined')
 
         _path = self.algorithm(self.Graph, from_node, to_node)[1]

--- a/src/FPEAM/data/inputs/ammonia_provider_params.csv
+++ b/src/FPEAM/data/inputs/ammonia_provider_params.csv
@@ -1,3 +1,11 @@
+# NH3 base-rate volatilisation fractions (lb NH3-N / lb N applied) at reference conditions
+# (T=15°C, wind=2 m/s, precip=0 mm, loam soil) derived from:
+#   Bouwman et al. (2002), Global Biogeochemical Cycles 16(2), doi:10.1029/2000GB001389
+#   Table 3 median values by fertilizer type.
+# These values are consistent with the static emission_factors.csv in this package
+# which was derived from the same source for the Billion Ton Study update.
+# t_ref_c, w_ref_m_s, p_ref_mm define the reference condition used to normalise
+# the modifier functions so that all modifiers equal 1.0 at reference.
 resource_subtype,base_rate_nh3,t_ref_c,w_ref_m_s,p_ref_mm
 anhydrous ammonia,0.040,15,2,0
 ammonium nitrate,0.008,15,2,0

--- a/src/FPEAM/data/inputs/geophysical_context_example.csv
+++ b/src/FPEAM/data/inputs/geophysical_context_example.csv
@@ -1,0 +1,24 @@
+# Example geophysical context file for use with the AmmoniaFertilizerProvider.
+# One row per region (county FIPS) and optionally per year/month.
+# The 'region' column must match region_production values in the production dataset.
+#
+# Column definitions:
+#   region          - County FIPS or other region key (str)
+#   year            - Scenario year (int, optional)
+#   month           - Month 1-12 (int, optional; omit for annual averages)
+#   temperature_c   - Mean application-period air temperature in °C (float)
+#   wind_speed_m_s  - Mean wind speed at 2 m height in m/s (float)
+#   precipitation_mm - Total precipitation over the 5 days post-application in mm (float)
+#   soil_type       - USDA texture class (str); see AmmoniaFertilizerProvider._f_soil
+#                     for valid values (sand, loamy sand, sandy loam, loam, silt loam,
+#                     silt, sandy clay loam, clay loam, silty clay loam, sandy clay,
+#                     silty clay, clay).
+#
+# Rows with unknown regions are ignored.
+# Missing optional columns default to reference conditions (T=15°C, wind=2 m/s,
+# precip=0 mm, loam) — see AmmoniaFertilizerProvider docs.
+region,year,temperature_c,wind_speed_m_s,precipitation_mm,soil_type
+17031,2017,22.5,3.2,45.0,silty clay loam
+17043,2017,19.1,2.8,30.0,loam
+17097,2017,21.0,3.5,20.0,silt loam
+26161,2017,17.3,4.1,55.0,loamy sand

--- a/tests/unit_tests/test_ammonia_provider.py
+++ b/tests/unit_tests/test_ammonia_provider.py
@@ -154,3 +154,30 @@ class TestAmmoniaProviderMissingContext:
         result = provider.factors(records)
         assert len(result) == 1
         assert 0 <= result['rate'].iloc[0] <= 1
+
+
+class TestAmmoniaProviderNegativeWind:
+
+    def test_negative_wind_clamped_to_zero(self):
+        """Negative wind speed is physically invalid; must not produce NaN."""
+        provider = AmmoniaFertilizerProvider()
+        records = pd.DataFrame([{
+            'region': '17031', 'resource': 'nitrogen',
+            'resource_subtype': 'urea',
+            'wind_speed_m_s': -1.0,  # physically impossible
+            'temperature_c': 15.0, 'precipitation_mm': 0.0, 'soil_type': 'loam',
+        }])
+        result = provider.factors(records)
+        assert len(result) == 1
+        assert not result['rate'].isna().any(), 'negative wind produced NaN rate'
+        # Clamped to 0 m/s; f_wind(0) = 0 so rate should be 0
+        assert result['rate'].iloc[0] == 0.0
+
+
+class TestAmmoniaProviderDefaultParams:
+
+    def test_params_csv_loads_without_error(self):
+        """The bundled ammonia_provider_params.csv with comment lines must parse cleanly."""
+        provider = AmmoniaFertilizerProvider()
+        assert set(provider._params.index) == AmmoniaFertilizerProvider.FERTILIZER_SUBTYPES
+        assert 'base_rate_nh3' in provider._params.columns

--- a/tests/unit_tests/test_fpeam_integration.py
+++ b/tests/unit_tests/test_fpeam_integration.py
@@ -78,30 +78,29 @@ class TestFPEAMCollect:
         assert (fpeam.results['pollutant_amount'] >= 0).all()
 
     def test_collect_loss_factor_measures_present(self, fpeam_run_config):
-        """collect() adds 'at biorefinery' feedstock-measure rows via the global loss factors.
-
-        NOTE: 'at farm gate' is currently absent because the bundled
-        feedstock_loss_factors.csv uses supply_chain_stage values of
-        'farm gate' and 'biorefinery gate', while FPEAM.collect() filters
-        for 'harvest', 'field treatment', 'field drying', 'on farm transport'.
-        The stage-name mismatch means the farmgate loss factor subset is always
-        empty for the bundled default data (documented; not a regression).
-        """
+        """collect() adds both 'at farm gate' and 'at biorefinery' feedstock-measure rows."""
         config, project = fpeam_run_config
         with FPEAM(run_config=config) as fpeam:
             fpeam.run()
         measures = set(fpeam.results['feedstock_measure'].unique())
         assert 'at biorefinery' in measures, 'expected at-biorefinery loss-factor rows'
-        # Document the known data/code mismatch without making it an error yet
-        if 'at farm gate' not in measures:
-            import warnings
-            warnings.warn(
-                "KNOWN: 'at farm gate' rows absent — bundled feedstock_loss_factors.csv "
-                "uses 'farm gate' but collect() filters for 'harvest'/'field treatment'/etc. "
-                "Track as p2-error-messages or similar for a future fix.",
-                UserWarning,
-                stacklevel=2,
-            )
+        assert 'at farm gate' in measures, \
+            ('at farm gate rows absent — the supply-chain-stage filter in '
+             'collect() must include "farm gate" to match the bundled data')
+
+    def test_collect_does_not_mutate_production(self, fpeam_run_config):
+        """collect() must not alter self.production (e.g. delete columns)."""
+        import pandas as pd
+        config, project = fpeam_run_config
+        with FPEAM(run_config=config) as fpeam:
+            cols_before = set(fpeam.production.columns)
+            fpeam.run()
+            cols_after = set(fpeam.production.columns)
+        # region_destination should survive; it was being deleted by collect()
+        assert 'region_destination' in cols_after, \
+            'collect() mutated self.production and deleted region_destination'
+        assert cols_before == cols_after, \
+            f'collect() changed production columns: {cols_before.symmetric_difference(cols_after)}'
 
     def test_collect_harvested_rows_present(self, fpeam_run_config):
         """collect() retains the raw 'harvested' measure rows."""

--- a/tests/unit_tests/test_region_emission_factors.py
+++ b/tests/unit_tests/test_region_emission_factors.py
@@ -159,3 +159,33 @@ class TestRegionKeyedFactors:
         rows_a = ef.results[ef.results['region_production'] == 'REGION_A']
         # With one feedstock measure row and one resource/subtype there should be exactly one result row
         assert len(rows_a) == 1
+
+
+class TestDynamicProviderNotYetWired:
+
+    def test_ammonia_fertilizer_provider_config_raises_not_implemented(self, ef_config):
+        """Configuring provider=ammonia_fertilizer must raise NotImplementedError
+        until the geophysical context → get_emissions() wiring is complete."""
+        import tempfile, os
+        from configobj import ConfigObj
+        cfg = ConfigObj(ef_config)
+        cfg['provider'] = 'ammonia_fertilizer'
+
+        equip = _equipment()
+        prod = _production_two_regions()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write(_NATIONAL_FACTORS_CSV)
+            ef_path = f.name
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write(_DISTRIBUTION_CSV)
+            rd_path = f.name
+        cfg['emission_factors'] = ef_path
+        cfg['resource_distribution'] = rd_path
+
+        try:
+            with pytest.raises(NotImplementedError):
+                EmissionFactors(config=cfg, equipment=equip, production=prod)
+        finally:
+            os.unlink(ef_path)
+            os.unlink(rd_path)

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -65,3 +65,27 @@ class TestRouterSmoke:
         # (0.01, 0.01) is closest to node 1 (0, 0)
         result = small_router.get_route(start=(0.01, 0.01), end=(0.99, 2.01))
         assert not result.empty
+
+
+@pytest.fixture(scope='module')
+def router_with_node_zero():
+    """Graph where valid node IDs start at 0 (exposes the 'if not node_id' false-positive)."""
+    import pandas as pd
+    edges = pd.DataFrame([
+        {'edge_id': 1, 'statefp': '17', 'countyfp': '001',
+         'u_of_edge': 0, 'v_of_edge': 1, 'weight': 1000.0, 'fclass': 1},
+    ])
+    node_map = pd.DataFrame([
+        {'node_id': 0, 'x': 0.0, 'y': 0.0},
+        {'node_id': 1, 'x': 0.0, 'y': 1.0},
+    ])
+    return Router(edges=edges, node_map=node_map, memory=None)
+
+
+class TestRouterNodeZero:
+
+    def test_route_from_node_zero_does_not_raise(self, router_with_node_zero):
+        """A graph with node_id=0 must not raise 'node is undefined' ValueError."""
+        result = router_with_node_zero.get_route(start=(0.0, 0.0), end=(0.0, 1.0))
+        assert not result.empty
+        assert '17001' in result['region_transportation'].values


### PR DESCRIPTION
Adversarial audit of all session changes targeting expert SE + air quality domain review. 90 tests pass.

## Fixes (6 commits)

**Critical correctness**
- `FPEAM.collect()` mutated `self.production` by deleting columns in-place, breaking any second call to `run()`. Fixed with `.copy()`.
- `FPEAM.collect()` also mutated `self.feedstock_loss_factors` via `eval(inplace=True)`. Fixed with `.assign()` on a copy.
- Supply-chain-stage filter (`harvest`/`field treatment`/...) did not match bundled data (`farm gate`). Extended the set to include both naming conventions; `at farm gate` rows now appear in results with default data.
- Region-fallback anti-join used `feedstock_amount` (float) as a join key — float equality in merge is fragile. Replaced with set-membership on `region_production` only.
- `Router.get_route` raised false-positive `ValueError` when `node_id == 0`. Replaced `if not (from_node and to_node)` with explicit `is None` check.

**Design / incomplete implementation**
- Dynamic provider (e.g. `ammonia_fertilizer`) was instantiated but `get_emissions()` never called it — silently using static rates instead. Added `NotImplementedError` with a clear message until the context-join wiring is complete.
- Windows `_run_moves_command` had two identical command branches (dead code). Collapsed to one.
- macOS path called `brew --prefix` via subprocess on every county run. Cached at module import time.

**Documentation**
- `ammonia_provider_params.csv`: added Bouwman 2002 citation, reference-condition notes, consistency note vs static table.
- Wind modifier: document and clamp negative inputs; precipitation default: clarify it is the maximum-volatilisation (conservative) assumption, not neutral.
- Added `geophysical_context_example.csv` with column descriptions and USDA texture vocabulary.