### PR TITLE
fix: round-3 audit — region fallback key bug, ammonia resource filter, docs

### DIFF
--- a/docs/emission_factor_providers.md
+++ b/docs/emission_factor_providers.md
@@ -78,15 +78,26 @@ NH3_fraction = base_rate(subtype)
 | `f_precip` | precipitation_mm | Exponential decay; dry=max, wet=reduced |
 | `f_soil` | soil_type (USDA texture) | Lookup table; clay > loam > sand |
 
-**Base rates** (bundled defaults from Bouwman 2002):
+**Base rates** (bundled defaults from Bouwman 2002, Table 3 median values):
 
-| Fertilizer subtype | Base rate (lb NH3 / lb N) |
-|---|---|
-| Anhydrous ammonia | 0.040 |
-| Ammonium nitrate | 0.008 |
-| Ammonium sulfate | 0.088 |
-| Urea | 0.025 |
-| Nitrogen solutions | 0.028 |
+| Fertilizer subtype | Base rate (lb NH3-N / lb N) | Notes |
+|---|---|---|
+| Anhydrous ammonia | 0.040 | See caveat below |
+| Ammonium nitrate | 0.008 | |
+| Ammonium sulfate | 0.088 | |
+| Urea | 0.025 | |
+| Nitrogen solutions | 0.028 | |
+
+**Important caveat — anhydrous ammonia application method**
+
+The Bouwman 2002 base rate of 0.040 applies to **surface-incorporated** anhydrous ammonia.
+Anhydrous ammonia is often injected below the soil surface (deep injection), which results
+in near-zero atmospheric NH3 volatilisation because the gas reacts immediately with soil
+moisture and is retained.  If your equipment dataset represents injected anhydrous ammonia,
+the correct rate is approximately 0.003–0.010 lb NH3-N / lb N.
+
+To model this distinction: supply a custom `provider_params` CSV that overrides the
+`anhydrous ammonia` base rate to reflect your application method.
 
 **Configuration**
 

--- a/src/FPEAM/EmissionFactorProviders/ammonia.py
+++ b/src/FPEAM/EmissionFactorProviders/ammonia.py
@@ -193,15 +193,17 @@ class AmmoniaFertilizerProvider(EmissionFactorProvider):
     def factors(self, records: pd.DataFrame) -> pd.DataFrame:
         """Return dynamic NH3 rates for each (region, resource_subtype) combination.
 
-        Only rows where ``resource == 'nitrogen'`` and ``resource_subtype`` is one
-        of the recognised fertilizer subtypes produce output rows.  For subtypes not
-        handled by this provider no rows are returned (fall through to TableProvider
-        or other providers in the chain).
+        Only rows where ``resource_subtype`` is one of the recognised nitrogen
+        fertilizer subtypes produce output rows.  When ``resource`` is present in
+        the input, rows where ``resource != 'nitrogen'`` are also excluded.  For
+        subtypes not handled by this provider no rows are returned (fall through to
+        TableProvider or other providers in the chain).
 
         Parameters
         ----------
         records : pd.DataFrame
             Must contain at minimum ``region`` and ``resource_subtype``.
+            When present, ``resource`` is used to restrict to nitrogen applications.
             Optional context: ``temperature_c``, ``wind_speed_m_s``,
             ``precipitation_mm``, ``soil_type``.
 
@@ -210,10 +212,23 @@ class AmmoniaFertilizerProvider(EmissionFactorProvider):
         pd.DataFrame
             One row per (region, resource_subtype, pollutant) combination with
             ``pollutant == 'nh3'``.
+
+        Application type caveat
+        -----------------------
+        The Bouwman 2002 base rates assume surface-incorporated fertilizer
+        application.  Anhydrous ammonia is often injected below the soil surface,
+        which produces near-zero atmospheric volatilisation.  If your equipment
+        data mixes injected and surface-applied anhydrous ammonia, the rate for
+        injected application should be set separately in the parameters CSV.
         """
-        _relevant = records[
-            records.get('resource_subtype', pd.Series(dtype=str)).isin(self.FERTILIZER_SUBTYPES)
-        ].copy() if 'resource_subtype' in records.columns else pd.DataFrame()
+        _mask = pd.Series(False, index=records.index)
+        if 'resource_subtype' in records.columns:
+            _mask = records['resource_subtype'].isin(self.FERTILIZER_SUBTYPES)
+            # Further restrict to nitrogen resource when the column is available
+            if 'resource' in records.columns:
+                _mask = _mask & (records['resource'].str.lower() == 'nitrogen')
+
+        _relevant = records[_mask].copy() if _mask.any() else pd.DataFrame()
 
         if _relevant.empty:
             # Return empty frame with the correct columns

--- a/src/FPEAM/EngineModules/EmissionFactors.py
+++ b/src/FPEAM/EngineModules/EmissionFactors.py
@@ -165,11 +165,23 @@ class EmissionFactors(Module):
             )
             _df_regional = _df_regional.drop(columns=['region'])
 
-            # apply national factors only to production regions NOT covered by
-            # a regional override.  Use the set of matched region_production
-            # values rather than a float-equality merge on feedstock_amount.
-            _covered_regions = set(_df_regional['region_production'].unique())
-            _base_national = _base[~_base['region_production'].isin(_covered_regions)]
+            # apply national factors only to (feedstock, resource, region_production)
+            # combinations NOT covered by a regional override.
+            # IMPORTANT: use a (feedstock, resource, region_production) triplet as
+            # the "covered" key.  Using region alone is wrong — a region that has an
+            # override for nitrogen but not for herbicide would lose its national
+            # herbicide factors if we only checked region membership.
+            _covered_keys = _df_regional[['feedstock', 'resource', 'region_production']]\
+                .drop_duplicates()
+            _base_national = _base.merge(
+                _covered_keys,
+                on=['feedstock', 'resource', 'region_production'],
+                how='left',
+                indicator=True,
+            )
+            _base_national = _base_national[
+                _base_national['_merge'] == 'left_only'
+            ].drop(columns=['_merge'])
 
             _df_national = _base_national.merge(_national_factors, on=['feedstock', 'resource'])
 

--- a/src/FPEAM/FPEAM.py
+++ b/src/FPEAM/FPEAM.py
@@ -248,11 +248,8 @@ class FPEAM(object):
 
         # rename the feedstock production units columns to avoid confusion
         # with the pollutant units columns in the results
-        _prod.rename(index=str, columns={'unit_numerator':
-                                         'feedstock_unit_numerator',
-                                         'unit_denominator':
-                                         'feedstock_unit_denominator'},
-                     inplace=True)
+        _prod = _prod.rename(columns={'unit_numerator': 'feedstock_unit_numerator',
+                                      'unit_denominator': 'feedstock_unit_denominator'})
 
         _prod_filtered = _prod[_prod_row_filter]
 

--- a/tests/unit_tests/test_region_emission_factors.py
+++ b/tests/unit_tests/test_region_emission_factors.py
@@ -189,3 +189,90 @@ class TestDynamicProviderNotYetWired:
         finally:
             os.unlink(ef_path)
             os.unlink(rd_path)
+
+
+class TestRegionFallbackPerResource:
+    """Regression for the region-only fallback bug.
+
+    A region with a nitrogen override must still receive national herbicide
+    factors.  Using region alone as the 'covered' key broke this.
+    """
+
+    def test_region_override_does_not_suppress_other_resources(self, ef_config):
+        """REGION_A gets nitrogen override AND national herbicide.
+        REGION_B (no override) gets national nitrogen AND national herbicide."""
+        import tempfile, os
+
+        factors_csv = (
+            'resource,resource_subtype,activity,pollutant,rate,unit_numerator,unit_denominator,region\n'
+            'nitrogen,anhydrous ammonia,chemical application,nh3,0.04,pound,pound,\n'
+            'nitrogen,anhydrous ammonia,chemical application,nh3,0.10,pound,pound,REGION_A\n'
+            'herbicide,generic herbicide,chemical application,voc,0.75,pound,pound,\n'
+        )
+        dist_csv = (
+            'feedstock,resource,resource_subtype,distribution\n'
+            'corn grain,nitrogen,anhydrous ammonia,1.0\n'
+            'corn grain,herbicide,generic herbicide,1.0\n'
+        )
+
+        equip_df = pd.DataFrame([
+            {'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+             'equipment_group': 'grp1', 'rotation_year': 1,
+             'activity': 'chemical application', 'equipment_name': 'tractor',
+             'equipment_horsepower': 100.0, 'resource': 'nitrogen', 'rate': 1.0,
+             'unit_numerator': 'lb', 'unit_denominator': 'ac'},
+            {'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+             'equipment_group': 'grp1', 'rotation_year': 1,
+             'activity': 'chemical application', 'equipment_name': 'sprayer',
+             'equipment_horsepower': 50.0, 'resource': 'herbicide', 'rate': 1.0,
+             'unit_numerator': 'lb', 'unit_denominator': 'ac'},
+        ])
+        prod_df = pd.DataFrame([
+            {'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+             'region_production': 'REGION_A', 'region_destination': 'REGION_A',
+             'equipment_group': 'grp1', 'feedstock_measure': 'harvested',
+             'feedstock_amount': 100.0, 'unit_numerator': 'dt', 'unit_denominator': 'ac',
+             'source_lon': -87.6, 'source_lat': 41.8,
+             'destination_lon': -87.6, 'destination_lat': 41.8},
+            {'feedstock': 'corn grain', 'tillage_type': 'conventional tillage',
+             'region_production': 'REGION_B', 'region_destination': 'REGION_B',
+             'equipment_group': 'grp1', 'feedstock_measure': 'harvested',
+             'feedstock_amount': 200.0, 'unit_numerator': 'dt', 'unit_denominator': 'ac',
+             'source_lon': -95.0, 'source_lat': 40.0,
+             'destination_lon': -95.0, 'destination_lat': 40.0},
+        ])
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write(factors_csv); ef_path = f.name
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+            f.write(dist_csv); rd_path = f.name
+
+        from configobj import ConfigObj
+        cfg = ConfigObj(ef_config)
+        cfg['emission_factors'] = ef_path
+        cfg['resource_distribution'] = rd_path
+
+        from FPEAM.Data import Equipment, Production
+        equip = Equipment(df=equip_df, backfill=False)
+        prod = Production(df=prod_df, backfill=False)
+
+        try:
+            ef = EmissionFactors(config=cfg, equipment=equip, production=prod)
+            ef.run()
+        finally:
+            os.unlink(ef_path); os.unlink(rd_path)
+
+        # REGION_A must have BOTH nitrogen (regional rate=0.10) AND herbicide (national rate=0.75)
+        ra = ef.results[ef.results['region_production'] == 'REGION_A']
+        assert 'nitrogen' in ra['resource'].values, 'REGION_A missing nitrogen results'
+        assert 'herbicide' in ra['resource'].values, \
+            'REGION_A missing herbicide results — region-only fallback bug'
+
+        # REGION_A nitrogen gets the regional rate (0.10, not national 0.04)
+        ra_n = ra[ra['resource'] == 'nitrogen']['pollutant_amount'].sum()
+        assert abs(ra_n - 10.0) < 1e-9, f'Expected REGION_A NH3=10.0, got {ra_n}'
+
+        # REGION_B must have both
+        rb = ef.results[ef.results['region_production'] == 'REGION_B']
+        assert 'nitrogen' in rb['resource'].values
+        assert 'herbicide' in rb['resource'].values


### PR DESCRIPTION
Third adversarial audit cycle — 3 commits, 91 tests pass.

**fix(EmissionFactors) — critical bug:** Region fallback used region alone as the covered key. A region with a nitrogen override was treated as fully covered, silently dropping national herbicide factors for that region. Fixed to use (feedstock, resource, region_production) triplet anti-join. Added TestRegionFallbackPerResource regression test.

**fix(ammonia):** AmmoniaFertilizerProvider.factors() filtered on resource_subtype only. Added resource=='nitrogen' filter when column is present. Also documents the application-method caveat (Bouwman 2002 base rate = surface-incorporated; injected anhydrous ammonia ≈ 0.003–0.010).

**refactor+docs:** FPEAM.collect() rename inplace→assignment. emission_factor_providers.md gets anhydrous ammonia injection caveat with guidance on overriding via custom params CSV.